### PR TITLE
Calc_psf docstring edits now in a decorator

### DIFF
--- a/webbpsf/utils.py
+++ b/webbpsf/utils.py
@@ -655,3 +655,22 @@ nlambda={nlambda:d}""".format(nlambda=nlambda))
 
 
     return _run_benchmark(timer, iterations=iterations)
+
+
+def combine_docstrings(cls):
+    """ Combine the docstrings of a method and earlier implementations of the same method in parent classes """
+    for name, func in cls.__dict__.items():
+
+        # Allow users to see the Poppy calc_psf docstring along with the JWInstrument version
+        if name == 'calc_psf':
+            jwinstrument_class = cls
+            spacetelescope_class = cls.__base__
+
+            ind0 = getattr(jwinstrument_class, 'calc_psf').__doc__.index("add_distortion")  # pull the new parameters
+            ind1 = getattr(spacetelescope_class, 'calc_psf').__doc__.index("Returns")  # end of parameters
+
+            func.__doc__ = getattr(spacetelescope_class, 'calc_psf').__doc__[0:ind1] + \
+                           getattr(jwinstrument_class, 'calc_psf').__doc__[ind0:] + \
+                           getattr(spacetelescope_class, 'calc_psf').__doc__[ind1:]
+
+    return cls

--- a/webbpsf/webbpsf_core.py
+++ b/webbpsf/webbpsf_core.py
@@ -607,6 +607,19 @@ class SpaceTelescopeInstrument(poppy.instrument.Instrument):
         filterfits.close()
         return band
 
+    @staticmethod
+    def include_other_docstrings():
+        def wrapper(func):
+            # Allow users to see poppy calc_psf docstring too
+            if func.__name__ == "calc_psf":
+                ind0 = func.__doc__.index("add_distortion")  # pull the new parameters
+                ind1 = getattr(SpaceTelescopeInstrument, func.__name__).__doc__.index("Returns")  # end of parameters
+                func.__doc__ = getattr(SpaceTelescopeInstrument, func.__name__).__doc__[0:ind1] + func.__doc__[ind0:] \
+                               + getattr(SpaceTelescopeInstrument, func.__name__).__doc__[ind1:]
+
+            return func
+        return wrapper
+
 
 #######  JWInstrument classes  #####
 
@@ -752,6 +765,7 @@ class JWInstrument(SpaceTelescopeInstrument):
                                            "[arcmin] Det. pos. in telescope V2,V3 coord sys"), after=True)
         result[0].header["APERNAME"] = (self._detectors[self._detector], "SIAF aperture name")
 
+    @SpaceTelescopeInstrument.include_other_docstrings()
     def calc_psf(self, outfile=None, source=None, nlambda=None, monochromatic=None,
                  fov_arcsec=None, fov_pixels=None, oversample=None, detector_oversample=None, fft_oversample=None,
                  overwrite=True, display=False, save_intermediates=False, return_intermediates=False,
@@ -787,11 +801,11 @@ class JWInstrument(SpaceTelescopeInstrument):
 
         return psf
 
-    # Allow users to see poppy calc_psf docstring too
-    ind0 = calc_psf.__doc__.index("add_distortion")  # pull the new parameters
-    ind1 = SpaceTelescopeInstrument.calc_psf.__doc__.index("Returns")  # pull where the parameters list ends
-    calc_psf.__doc__ = SpaceTelescopeInstrument.calc_psf.__doc__[0:ind1] + calc_psf.__doc__[ind0:] + \
-                       SpaceTelescopeInstrument.calc_psf.__doc__[ind1:]
+    # # Allow users to see poppy calc_psf docstring too
+    # ind0 = calc_psf.__doc__.index("add_distortion")  # pull the new parameters
+    # ind1 = SpaceTelescopeInstrument.calc_psf.__doc__.index("Returns")  # pull where the parameters list ends
+    # calc_psf.__doc__ = SpaceTelescopeInstrument.calc_psf.__doc__[0:ind1] + calc_psf.__doc__[ind0:] + \
+    #                    SpaceTelescopeInstrument.calc_psf.__doc__[ind1:]
 
     def _calc_psf_format_output(self, result, options):
         """

--- a/webbpsf/webbpsf_core.py
+++ b/webbpsf/webbpsf_core.py
@@ -760,7 +760,7 @@ class JWInstrument(SpaceTelescopeInstrument):
 
         Parameters
         ----------
-       add_distortion : bool
+        add_distortion : bool
             If True, will add 2 new extensions to the PSF HDUlist object. The 2nd extension
             will be a distorted version of the over-sampled PSF and the 3rd extension will
             be a distorted version of the detector-sampled PSF.

--- a/webbpsf/webbpsf_core.py
+++ b/webbpsf/webbpsf_core.py
@@ -801,12 +801,6 @@ class JWInstrument(SpaceTelescopeInstrument):
 
         return psf
 
-    # # Allow users to see poppy calc_psf docstring too
-    # ind0 = calc_psf.__doc__.index("add_distortion")  # pull the new parameters
-    # ind1 = SpaceTelescopeInstrument.calc_psf.__doc__.index("Returns")  # pull where the parameters list ends
-    # calc_psf.__doc__ = SpaceTelescopeInstrument.calc_psf.__doc__[0:ind1] + calc_psf.__doc__[ind0:] + \
-    #                    SpaceTelescopeInstrument.calc_psf.__doc__[ind1:]
-
     def _calc_psf_format_output(self, result, options):
         """
         Add distortion to the created 1-extension PSF

--- a/webbpsf/webbpsf_core.py
+++ b/webbpsf/webbpsf_core.py
@@ -608,16 +608,18 @@ class SpaceTelescopeInstrument(poppy.instrument.Instrument):
         return band
 
     @staticmethod
-    def include_other_docstrings():
+    def combine_docstrings():
+        """ Combine the docstrings of a method and earlier implementations of the same method in parent classes """
+
         def wrapper(func):
-            # Allow users to see poppy calc_psf docstring too
+            # Allow users to see Poppy calc_psf docstring along with the JWInstrument version
             if func.__name__ == "calc_psf":
                 ind0 = func.__doc__.index("add_distortion")  # pull the new parameters
                 ind1 = getattr(SpaceTelescopeInstrument, func.__name__).__doc__.index("Returns")  # end of parameters
                 func.__doc__ = getattr(SpaceTelescopeInstrument, func.__name__).__doc__[0:ind1] + func.__doc__[ind0:] \
                                + getattr(SpaceTelescopeInstrument, func.__name__).__doc__[ind1:]
-
             return func
+
         return wrapper
 
 
@@ -765,7 +767,7 @@ class JWInstrument(SpaceTelescopeInstrument):
                                            "[arcmin] Det. pos. in telescope V2,V3 coord sys"), after=True)
         result[0].header["APERNAME"] = (self._detectors[self._detector], "SIAF aperture name")
 
-    @SpaceTelescopeInstrument.include_other_docstrings()
+    @SpaceTelescopeInstrument.combine_docstrings()
     def calc_psf(self, outfile=None, source=None, nlambda=None, monochromatic=None,
                  fov_arcsec=None, fov_pixels=None, oversample=None, detector_oversample=None, fft_oversample=None,
                  overwrite=True, display=False, save_intermediates=False, return_intermediates=False,

--- a/webbpsf/webbpsf_core.py
+++ b/webbpsf/webbpsf_core.py
@@ -607,25 +607,10 @@ class SpaceTelescopeInstrument(poppy.instrument.Instrument):
         filterfits.close()
         return band
 
-    @staticmethod
-    def combine_docstrings():
-        """ Combine the docstrings of a method and earlier implementations of the same method in parent classes """
-
-        def wrapper(func):
-            # Allow users to see Poppy calc_psf docstring along with the JWInstrument version
-            if func.__name__ == "calc_psf":
-                ind0 = func.__doc__.index("add_distortion")  # pull the new parameters
-                ind1 = getattr(SpaceTelescopeInstrument, func.__name__).__doc__.index("Returns")  # end of parameters
-                func.__doc__ = getattr(SpaceTelescopeInstrument, func.__name__).__doc__[0:ind1] + func.__doc__[ind0:] \
-                               + getattr(SpaceTelescopeInstrument, func.__name__).__doc__[ind1:]
-            return func
-
-        return wrapper
-
 
 #######  JWInstrument classes  #####
 
-
+@utils.combine_docstrings
 class JWInstrument(SpaceTelescopeInstrument):
     """ Superclass for all JWST instruments
 
@@ -767,7 +752,6 @@ class JWInstrument(SpaceTelescopeInstrument):
                                            "[arcmin] Det. pos. in telescope V2,V3 coord sys"), after=True)
         result[0].header["APERNAME"] = (self._detectors[self._detector], "SIAF aperture name")
 
-    @SpaceTelescopeInstrument.combine_docstrings()
     def calc_psf(self, outfile=None, source=None, nlambda=None, monochromatic=None,
                  fov_arcsec=None, fov_pixels=None, oversample=None, detector_oversample=None, fft_oversample=None,
                  overwrite=True, display=False, save_intermediates=False, return_intermediates=False,
@@ -858,12 +842,6 @@ class JWInstrument(SpaceTelescopeInstrument):
 
         # Rewrite result variable based on output_mode set:
         SpaceTelescopeInstrument._calc_psf_format_output(self, result, options)
-
-    # Allow users to see poppy calc_psf docstring too
-    ind0 = calc_psf.__doc__.index("add_distortion")  # pull the new parameters
-    ind1 = SpaceTelescopeInstrument.calc_psf.__doc__.index("Returns")  # pull where the parameters list ends
-    calc_psf.__doc__ = SpaceTelescopeInstrument.calc_psf.__doc__[0:ind1] + calc_psf.__doc__[ind0:] + \
-                       SpaceTelescopeInstrument.calc_psf.__doc__[ind1:]
 
     def interpolate_was_opd(self, array, newdim):
         """ Interpolates an input 2D  array to any given size.


### PR DESCRIPTION
The combination of the JWInstrument calc_psf docstring and the Poppy Instrument calc_psf docstring is now located in the combine_docstrings method and applied to the JWInstrument calc_psf as a decorator.