### PR TITLE
Shift distorted PSFs back to correct detector position

### DIFF
--- a/webbpsf/distortion.py
+++ b/webbpsf/distortion.py
@@ -119,6 +119,10 @@ def apply_distortion(hdulist_or_filename=None, fill_value=0):
     xnew += xpix_center
     ynew += ypix_center
 
+    # 5) Shift the new indices so the center matches the sci indices
+    xnew += np.mean(xsci) - np.mean(xnew)
+    ynew += np.mean(ysci) - np.mean(ynew)
+
     # ###############################################
     # Interpolate from the original indices (xsci, ysci) on to new indices (xnew, ynew)
     # noinspection PyTypeChecker

--- a/webbpsf/distortion.py
+++ b/webbpsf/distortion.py
@@ -101,6 +101,10 @@ def apply_distortion(hdulist_or_filename=None, fill_value=0):
     # Going from Idl to Sci this way allows us to add in the distortion
     xsci, ysci = aper.idl_to_sci(xidl, yidl)
 
+    # 6) Shift the sci indices so they match the PSF's position again (moved slightly off from pysiaf calculation)
+    xsci += xpix_center - np.median(xsci)
+    ysci += ypix_center - np.median(ysci)
+
     # ###############################################
     # Create an array of indices (in pixels) that the final data will be interpolated on to
     # 1) Set up blank indices (in pixels)
@@ -118,10 +122,6 @@ def apply_distortion(hdulist_or_filename=None, fill_value=0):
     # 4) Shift the indices so they match where on the detector the PSF is located
     xnew += xpix_center
     ynew += ypix_center
-
-    # 5) Shift the new indices so the center matches the sci indices
-    xnew += np.mean(xsci) - np.mean(xnew)
-    ynew += np.mean(ysci) - np.mean(ynew)
 
     # ###############################################
     # Interpolate from the original indices (xsci, ysci) on to new indices (xnew, ynew)

--- a/webbpsf/distortion.py
+++ b/webbpsf/distortion.py
@@ -1,13 +1,11 @@
-import copy
-
 import astropy.convolution
 import astropy.io.fits as fits
+import copy
 import numpy as np
+import poppy
 import pysiaf
 from scipy.interpolate import griddata
 from scipy.ndimage.interpolation import rotate
-
-import poppy
 
 
 def _get_default_siaf(instrument, aper_name):


### PR DESCRIPTION
When distorting a PSF, now the indices we interpolate from and on to have (approximately) the same center point. This fixes issue raised in #226 
