### PR TITLE
Bug Fix: Documentation build failing on Travis

### DIFF
--- a/webbpsf/webbpsf_core.py
+++ b/webbpsf/webbpsf_core.py
@@ -849,12 +849,6 @@ class JWInstrument(SpaceTelescopeInstrument):
         # Rewrite result variable based on output_mode set:
         SpaceTelescopeInstrument._calc_psf_format_output(self, result, options)
 
-    # Allow users to see poppy calc_psf docstring too
-    ind0 = calc_psf.__doc__.index("add_distortion")  # pull the new parameters
-    ind1 = SpaceTelescopeInstrument.calc_psf.__doc__.index("Returns")  # pull where the parameters list ends
-    calc_psf.__doc__ = SpaceTelescopeInstrument.calc_psf.__doc__[0:ind1] + calc_psf.__doc__[ind0:] + \
-                       SpaceTelescopeInstrument.calc_psf.__doc__[ind1:]
-
     def interpolate_was_opd(self, array, newdim):
         """ Interpolates an input 2D  array to any given size.
 

--- a/webbpsf/webbpsf_core.py
+++ b/webbpsf/webbpsf_core.py
@@ -760,7 +760,7 @@ class JWInstrument(SpaceTelescopeInstrument):
 
         Parameters
         ----------
-       add_distortion : bool
+        add_distortion : bool
             If True, will add 2 new extensions to the PSF HDUlist object. The 2nd extension
             will be a distorted version of the over-sampled PSF and the 3rd extension will
             be a distorted version of the detector-sampled PSF.


### PR DESCRIPTION
Closes #233 
This PR resolves the Travis doc build failure. It turns out the failure is caused by duplicate code that defines `calc_psf.__doc__` in `webbpsf_core.JWInstrument` :

[First instance (L790)](https://github.com/spacetelescope/webbpsf/blob/master/webbpsf/webbpsf_core.py#L790-L794)
[Second instance (L852)](https://github.com/spacetelescope/webbpsf/blob/master/webbpsf/webbpsf_core.py#L852-L856)

The duplicate was introduced in this [merge with master](https://github.com/spacetelescope/webbpsf/commit/6c7fc717406e6797883ea79b8b6f0117263e0448#diff-1340a819c5a9f36ab275cd31b8866138R791). 