### PR TITLE
Add unit test for defocus and weak lens. Fixes #59

### DIFF
--- a/webbpsf/tests/test_nircam.py
+++ b/webbpsf/tests/test_nircam.py
@@ -311,6 +311,7 @@ def test_defocus(fov_arcsec=1, display=False):
     assert np.allclose(psf[0].data, psf_2[0].data), "Defocused PSFs calculated two ways don't agree"
 
     if display:
+        import webbpsf
         plt.figure()
         webbpsf.display_psf(psf)
         plt.figure()


### PR DESCRIPTION
This PR fixes the long-standing issue (#59) of there not being a test case for any of the defocus options. 
No changes in package functionality; this just adds a test. 