### PR TITLE
Use shift_x/shift_y instead of shift for pupil shifts. Relies on poppy 247 fix. 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ env:
         - NUMPY_VERSION=stable
         - ASTROPY_VERSION=stable
         - SETUP_CMD='test'
-        - PIP_DEPENDENCIES='git+https://github.com/mperrin/poppy.git#egg=poppy jwxml git+https://github.com/spacetelescope/pysiaf.git#egg=pysiaf nbsphinx Sphinx==1.5.6 git+https://github.com/astropy/photutils.git#egg=phoutils'
+        - PIP_DEPENDENCIES='git+https://github.com/spacetelescope/poppy.git#egg=poppy jwxml git+https://github.com/spacetelescope/pysiaf.git#egg=pysiaf nbsphinx Sphinx==1.5.6 git+https://github.com/astropy/photutils.git#egg=phoutils'
         - CONDA_DEPENDENCIES='scipy matplotlib six cython'
 
         # For headless testing of code that imports PyPlot:
@@ -45,7 +45,7 @@ matrix:
         - python: 3.6
           env: SETUP_CMD='build_sphinx'
                 CONDA_DEPENDENCIES='scipy matplotlib six cython nbsphinx pandoc'
-                PIP_DEPENDENCIES='git+https://github.com/mperrin/poppy.git#egg=poppy jwxml git+https://github.com/spacetelescope/pysiaf.git#egg=pysiaf nbsphinx Sphinx==1.5.6 git+https://github.com/astropy/photutils.git#egg=phoutils sphinx_rtd_theme stsci_rtd_theme sphinx-automodapi'
+                PIP_DEPENDENCIES='git+https://github.com/spacetelescope/poppy.git#egg=poppy jwxml git+https://github.com/spacetelescope/pysiaf.git#egg=pysiaf nbsphinx Sphinx==1.5.6 git+https://github.com/astropy/photutils.git#egg=phoutils sphinx_rtd_theme stsci_rtd_theme sphinx-automodapi'
 
         # Try Astropy development version
         - python: 3.6


### PR DESCRIPTION
Required before PR #256. This updates all the instrument-specific optical elements to use the shift_x/shift_y arguments in meters, rather than shift in percent of the pupil. A new helper function is added to perform the necessary conversion consistently for all instruments. 

This will only work with a version of poppy after https://github.com/spacetelescope/poppy/pull/274 has been merged. 

In most cases this re-arrangement gives the same result in the end. It does fix a bug for the weak lenses for defocus. 