### PR TITLE
Missing import in Gridded_PSF_library notebook

### DIFF
--- a/notebooks/Gridded_PSF_Library.ipynb
+++ b/notebooks/Gridded_PSF_Library.ipynb
@@ -46,6 +46,7 @@
    "outputs": [],
    "source": [
     "from astropy.io import fits\n",
+    "import matplotlib\n",
     "import webbpsf\n",
     "from webbpsf.utils import to_griddedpsfmodel\n",
     "print(\"Notebook tested with WebbPSF 0.8.0, currently running on WebbPSF\", webbpsf.version.version)"


### PR DESCRIPTION
`import matplotlib` was missing from the Gridded_PSF_Library notebook (it is called in `matplotlib.colors.LogNorm` but was never imported).