### PR TITLE
Update RTD min numpy version, as needed for astropy 3.1

### DIFF
--- a/docs/rtd-pip-requirements
+++ b/docs/rtd-pip-requirements
@@ -1,5 +1,5 @@
 stsci_rtd_theme
-numpy
+numpy >= 1.13
 matplotlib
 Cython
 astropy-helpers


### PR DESCRIPTION
Not sure why Travis isn't doing this automatically if it's installing an astropy version that needs it...