### PR TITLE
Write existing opd_header to HDUList in opd.as_fits()

### DIFF
--- a/webbpsf/opds.py
+++ b/webbpsf/opds.py
@@ -191,9 +191,9 @@ class OPD(poppy.FITSOpticalElement):
             Include the pupil mask as a FITS extension?
         """
 
-        output = fits.HDUList([fits.ImageHDU(self.opd)])
+        output = fits.HDUList([fits.ImageHDU(self.opd, self.opd_header)])
         output[0].header['EXTNAME'] = 'OPD'
-        output[0].header['BUNIT'] = 'meter'  # Will this always be the case?
+        output[0].header['BUNIT'] = 'meter'  # Rescaled to meters in poppy_core
 
         if include_pupil:
             self.amplitude_header['EXTNAME'] = 'PUPIL'


### PR DESCRIPTION
I realized that when I re-wrote the `opd.as_fits()` method (#232), I didn't include the existing OPD header information in the HDUList object that gets written out.

This tiny PR includes all of the info in the `opd_header` attribute when writing that HDUList object.