### PR TITLE
Add R062 Fix to relnotes.rst

### DIFF
--- a/docs/relnotes.rst
+++ b/docs/relnotes.rst
@@ -31,7 +31,10 @@ Road Map for Future Releases
 
 Version History and Change Log
 -------------------------------
-
+Version 0.8.1
+=============
+**Bug fixes and small changes:**
+- The WFIRST R026 filter bandpass red edge was corrected from 8000A to 7600A (@robelgeda)
 
 Version 0.8.0
 =============

--- a/docs/relnotes.rst
+++ b/docs/relnotes.rst
@@ -34,7 +34,7 @@ Version History and Change Log
 Version 0.8.1
 =============
 **Bug fixes and small changes:**
-- The WFIRST R026 filter bandpass red edge was corrected from 8000A to 7600A (@robelgeda)
+- The WFIRST R062 filter bandpass red edge was corrected from 8000A to 7600A (@robelgeda)
 
 Version 0.8.0
 =============


### PR DESCRIPTION
This adds a small note on the the R026 bandpass fix to the `docs/relnotes.rst`