### PR TITLE
fix astropy.tests.pytest_plugins error

### DIFF
--- a/webbpsf/conftest.py
+++ b/webbpsf/conftest.py
@@ -2,7 +2,11 @@
 # by importing them here in conftest.py they are discoverable by py.test
 # no matter how it is invoked within the source tree.
 
-from astropy.tests.pytest_plugins import *
+try:
+    from astropy.tests.plugins.display import *
+    from astropy.tests.helper import *
+except ImportError:
+    from astropy.tests.pytest_plugins import *
 
 ## Uncomment the following line to treat all DeprecationWarnings as
 ## exceptions


### PR DESCRIPTION
Fix for astropy.tests.pytest_plugins problem- same fix as was in poppy. See discussion of issue here: https://github.com/spacetelescope/poppy/issues/289 