### PR TITLE
Fix for saving GriddedPSFModel into FITS file

### DIFF
--- a/webbpsf/gridded_library.py
+++ b/webbpsf/gridded_library.py
@@ -270,7 +270,7 @@ class CreatePSFLibrary:
             meta["INSTRUME"] = (self.instr, "Instrument name")
             meta["DETECTOR"] = (det, "Detector name")
             meta["FILTER"] = (self.filter, "Filter name")
-            meta["PUPILOPD"] = (self.webb.pupilopd, "Pupil OPD source name")
+            meta["PUPILOPD"] = (psf[ext].header["PUPILOPD"], "Pupil OPD source name")
 
             meta["FOVPIXEL"] = (self.fov_pixels, "Field of view in pixels (full array)")
             meta["FOV"] = (psf[ext].header["FOV"], "Field of view in arcsec (full array)")


### PR DESCRIPTION
There was an issue with setting the WFE information in the FITS header. To fix this, you can just pull that information from the header of the individual PSF so it's already properly formatted, rather than re-format it here as well.

Fixes #282 