### PR TITLE
WFIRST Filter Tests and Wave Approx

### DIFF
--- a/webbpsf/tests/test_wfirst.py
+++ b/webbpsf/tests/test_wfirst.py
@@ -1,5 +1,7 @@
 import pytest
 from webbpsf import wfirst
+from numpy import allclose
+
 
 def test_WFI_psf():
     """
@@ -8,6 +10,16 @@ def test_WFI_psf():
     """
     wi = wfirst.WFI()
     wi.calc_psf(fov_pixels=4)
+
+
+def test_WFI_filters():
+    wi = wfirst.WFI()
+    filter_list = wi.filter_list
+    for filter in filter_list:
+        wi = wfirst.WFI()
+        wi.filter = filter
+        wi.calc_psf(fov_pixels=4, oversample=1, nlambda=3)
+
 
 def test_aberration_detector_position_setter():
     detector = wfirst.FieldDependentAberration(4096, 4096)
@@ -49,7 +61,7 @@ def test_WFI_detector_position_setter():
 def test_WFI_includes_aberrations():
     wfi = wfirst.WFI()
     wfi.detector = 'SCA01'
-    osys = wfi._getOpticalSystem()
+    osys = wfi._get_optical_system()
     assert isinstance(osys[2], wfirst.FieldDependentAberration), (
         "Third plane of WFIRST WFI optical system should be the "
         "field dependent aberration virtual optic"
@@ -82,6 +94,8 @@ def test_WFI_chooses_pupil_masks():
 
     _test_filter_pupil('Y106', wfi._unmasked_pupil_path)
     _test_filter_pupil('J129', wfi._unmasked_pupil_path)
+    _test_filter_pupil('R062', wfi._unmasked_pupil_path)
+
     _test_filter_pupil('H158', wfi._masked_pupil_path)
     _test_filter_pupil('F184', wfi._masked_pupil_path)
     _test_filter_pupil('W149', wfi._masked_pupil_path)
@@ -102,10 +116,15 @@ def test_WFI_limits_interpolation_range():
         "FieldDependentAberration did not error on out-of-bounds field point"
     )
     det.field_position = (2048, 2048)
-    with pytest.raises(RuntimeError) as excinfo:
-        det.get_aberration_terms(5e-6)
-    assert 'wavelength outside the range' in str(excinfo.value), (
-        "FieldDependentAberration did not error on out-of-bounds wavelength"
+
+    # Test the get_aberration_terms function uses approximated wavelength when
+    # called with an out-of-bound wavelength.
+    assert allclose(det.get_aberration_terms(5e-6), det.get_aberration_terms(2e-6)), (
+        "Aberration outside wavelength range did not return closest value."
+    )
+
+    assert allclose(det.get_aberration_terms(1e-7), det.get_aberration_terms(0.76e-6)), (
+        "Aberration outside wavelength range did not return closest value."
     )
 
 def test_CGI_detector_position():

--- a/webbpsf/tests/test_wfirst.py
+++ b/webbpsf/tests/test_wfirst.py
@@ -61,7 +61,7 @@ def test_WFI_detector_position_setter():
 def test_WFI_includes_aberrations():
     wfi = wfirst.WFI()
     wfi.detector = 'SCA01'
-    osys = wfi._get_optical_system()
+    osys = wfi._getOpticalSystem()
     assert isinstance(osys[2], wfirst.FieldDependentAberration), (
         "Third plane of WFIRST WFI optical system should be the "
         "field dependent aberration virtual optic"

--- a/webbpsf/wfirst.py
+++ b/webbpsf/wfirst.py
@@ -65,8 +65,12 @@ class WavelengthDependenceInterpolator(object):
             # we have to interpolate @ this wavelength
             aberration_terms = griddata(self._wavelengths, self._aberration_terms, wavelength, method='linear')
             if np.any(np.isnan(aberration_terms)):
-                raise RuntimeError("Attempted to get aberrations at wavelength "
-                                   "outside the range of the reference data")
+                import warnings
+                wavelength_closest = np.clip(wavelength.value, np.min(self._wavelengths), np.max(self._wavelengths))
+                _log.warn("Attempted to get aberrations at wavelength {:.2g} "
+                        "outside the range of the reference data; clipping to closest wavelength {:.2g}".format(wavelength, wavelength_closest))
+
+                aberration_terms = griddata(self._wavelengths, self._aberration_terms, wavelength_closest, method='linear')
             return aberration_terms
 
 

--- a/webbpsf/wfirst.py
+++ b/webbpsf/wfirst.py
@@ -14,6 +14,7 @@ import numpy as np
 from . import webbpsf_core
 from scipy.interpolate import griddata
 from astropy.io import fits
+import astropy.units as u
 import logging
 
 _log = logging.getLogger('webbpsf')
@@ -65,14 +66,16 @@ class WavelengthDependenceInterpolator(object):
             # we have to interpolate @ this wavelength
             aberration_terms = griddata(self._wavelengths, self._aberration_terms, wavelength, method='linear')
             if np.any(np.isnan(aberration_terms)):
-                import warnings
-                wavelength_closest = np.clip(wavelength.value, np.min(self._wavelengths), np.max(self._wavelengths))
+                if isinstance(wavelength, u.Quantity):
+                    wavelength = wavelength.to(u.m).value
+                wavelength_closest = np.clip(wavelength, np.min(self._wavelengths), np.max(self._wavelengths))
                 _log.warn("Attempted to get aberrations at wavelength {:.2g} "
-                        "outside the range of the reference data; clipping to closest wavelength {:.2g}".format(wavelength, wavelength_closest))
+                          "outside the range of the reference data; clipping to closest wavelength {:.2g}".format(
+                    wavelength, wavelength_closest))
 
-                aberration_terms = griddata(self._wavelengths, self._aberration_terms, wavelength_closest, method='linear')
+                aberration_terms = griddata(self._wavelengths, self._aberration_terms, wavelength_closest,
+                                            method='linear')
             return aberration_terms
-
 
 class FieldDependentAberration(poppy.ZernikeWFE):
     """FieldDependentAberration incorporates aberrations that


### PR DESCRIPTION
This PR adds tests for the R062 filter in the WFIRST module.
Rather than raising a RuntimeError, it now prints a warning and gives the best estimate result anyway. 
fixes #285 
