### PR TITLE
Change removal of different keywords

### DIFF
--- a/webbpsf/gridded_library.py
+++ b/webbpsf/gridded_library.py
@@ -369,7 +369,7 @@ class CreatePSFLibrary:
                                   for key in ndd.meta.keys() if "DET_YX" in key]
 
         ndd.meta['oversampling'] = meta["OVERSAMP"][0]  # just pull the value
-        ndd.meta = {key.lower(): ndd.meta[key] for key in ndd.meta if "DET_YX" not in key and "OVERSAMP" not in key}
+        ndd.meta = {key.lower(): ndd.meta[key] for key in ndd.meta}
 
         model = GriddedPSFModel(ndd)
 

--- a/webbpsf/utils.py
+++ b/webbpsf/utils.py
@@ -719,8 +719,9 @@ def to_griddedpsfmodel(HDUlist_or_filename=None, ext=0):
 
     # Convert header to meta dict
     header = header.copy(strip=True)
-    header.remove('COMMENT', remove_all=True)
-    header.remove('', remove_all=True)
+    header.pop('COMMENT', None)
+    header.pop('', None)
+    header.pop('HISTORY', None)
     meta = OrderedDict((a, (b, c)) for (a, b, c) in header.cards)
 
     ndd = NDData(data, meta=meta, copy=True)
@@ -734,7 +735,7 @@ def to_griddedpsfmodel(HDUlist_or_filename=None, ext=0):
         ndd.meta['oversampling'] = ndd.meta['OVERSAMP'][0]  # pull the value
 
     # Remove keys with duplicate information
-    ndd.meta = {key.lower(): ndd.meta[key] for key in ndd.meta if 'DET_YX' not in key and 'OVERSAMP' not in key}
+    ndd.meta = {key.lower(): ndd.meta[key] for key in ndd.meta}
 
     # Create model
     model = GriddedPSFModel(ndd)

--- a/webbpsf/utils.py
+++ b/webbpsf/utils.py
@@ -734,7 +734,7 @@ def to_griddedpsfmodel(HDUlist_or_filename=None, ext=0):
     if 'oversampling' not in ndd.meta:
         ndd.meta['oversampling'] = ndd.meta['OVERSAMP'][0]  # pull the value
 
-    # Remove keys with duplicate information
+    # Turn all metadata keys into lowercase
     ndd.meta = {key.lower(): ndd.meta[key] for key in ndd.meta}
 
     # Create model


### PR DESCRIPTION
@laurenmarietta is using the psf grid functionality in mirage and these changes should make it's implementation there easier while also not changing anything important for users following the original workflow.

This PR:
1. In `to_model()` and `to_griddedpsfmodel()`: No longer deletes the duplicate keywords of `DET_YX*` and `OVERSAMP` (so now normal users will just have some extra keywords which shouldn't hurt anything)
2. In `to_griddedpsfmodel()`: Now uses pop to delete un-needed keys so that if those keys aren't present, it doesn't throw an error