### PR TITLE
Feature/sm sur

### DIFF
--- a/webbpsf/opds.py
+++ b/webbpsf/opds.py
@@ -1705,7 +1705,11 @@ class OTE_Linear_Model_WSS(OPD):
         import jwxml
 
         sur = jwxml.SUR(sur_file)
-        for grp in sur.groups:
+        if group is not None:
+            groups = [sur.groups[group]]
+        else:
+            groups = sur.groups
+        for grp in groups:
             for update in grp:
                 if verbose:
                     print("Move seg {} by {}".format(update.segment, str(update)))

--- a/webbpsf/opds.py
+++ b/webbpsf/opds.py
@@ -1699,7 +1699,20 @@ class OTE_Linear_Model_WSS(OPD):
             self.update_opd(display=display)
 
     def move_sur(self, sur_file, group=None, verbose=False):
-        """ Move using a JWST Segment Update Request file
+        """
+        Move using a JWST Segment Update Request file
+
+        Parameters
+        ----------
+        sur_file : file name
+            Path to SUR XML file
+        group : zero-based int index
+            Index to a single group to run. Default is to run all groups.
+        verbose : bool
+            Flag controlling whether moves are printed.
+
+        Returns
+        -------
 
         """
         import jwxml

--- a/webbpsf/opds.py
+++ b/webbpsf/opds.py
@@ -1325,7 +1325,7 @@ class OTE_Linear_Model_WSS(OPD):
         roc : float
             radius of curvature mechanism adjustment, in microns.
         trans_unit : str
-            Unit for translations. Can be 'micron', 'millimeter','nanometer', 'mm', 'nm', 'um'
+            Unit for translations. Can be 'meter', 'micron', 'millimeter', 'nanometer', 'm', 'mm', 'nm', 'um'
         rot_unit : str
             Unit for rotations. Can be 'urad', 'radian', 'milliradian', 'arcsec', 'arcmin', 'milliarcsec'
         absolute : bool

--- a/webbpsf/opds.py
+++ b/webbpsf/opds.py
@@ -1620,6 +1620,8 @@ class OTE_Linear_Model_WSS(OPD):
                 vector *= 1000
             elif trans_unit == 'nm' or trans_unit == 'nanometer' or trans_unit == 'nanometers':
                 vector /= 1000
+            elif trans_unit == 'meter':
+                vector *= 1000000
             else:
                 raise ValueError("Unknown trans_unit for length: %s" % trans_unit)
 
@@ -1716,16 +1718,26 @@ class OTE_Linear_Model_WSS(OPD):
                     rot_unit = update.units['X_TILT']
                     trans_unit = update.units['X_TRANS']
 
-                    self.move_seg_local(update.segment[0:2],
-                                        xtilt=update.moves['X_TILT'],
-                                        ytilt=update.moves['Y_TILT'],
-                                        xtrans=update.moves['X_TRANS'],
-                                        ytrans=update.moves['Y_TRANS'],
-                                        piston=update.moves['PISTON'],
-                                        absolute=update.absolute,
-                                        rot_unit=rot_unit,
-                                        trans_unit=trans_unit,
-                                        delay_update=True)
+                    if update.segment == 'SM':
+                        self.move_sm_local(xtilt=update.moves['X_TILT'],
+                                           ytilt=update.moves['Y_TILT'],
+                                           xtrans=update.moves['X_TRANS'],
+                                           ytrans=update.moves['Y_TRANS'],
+                                           piston=update.moves['PISTON'],
+                                           rot_unit=rot_unit,
+                                           trans_unit=trans_unit,
+                                           delay_update=True)
+                    else:
+                        self.move_seg_local(update.segment[0:2],
+                                            xtilt=update.moves['X_TILT'],
+                                            ytilt=update.moves['Y_TILT'],
+                                            xtrans=update.moves['X_TRANS'],
+                                            ytrans=update.moves['Y_TRANS'],
+                                            piston=update.moves['PISTON'],
+                                            absolute=update.absolute,
+                                            rot_unit=rot_unit,
+                                            trans_unit=trans_unit,
+                                            delay_update=True)
 
                 elif update.type == 'roc':
                     self.move_seg_local(update.segment[0:2],


### PR DESCRIPTION
This branch adds support for SM moves to the move_sur() method. Because segment moves are made through move_seg_local and SM moves are made through move_sm_local, this requires a check in move_sur on whether the segment is, in fact, the SM, and take a different code path if it is. 

In the course of this I also implemented the group= keyword argument which was previously ignored. The behaviour was unspecified so I made it take a zero-based index into the groups and execute that one. 

I also added support for moves in meters because the SUR in order to process the GA SUR I was working with it. 

I can rebase this branch off of your current master or latest merge commit if you prefer a cleaner history.

I'm not sure why my webbpsf master branch picked up the 2018-12 base commit its branched from. 


