### PR TITLE
Use nearest aberration terms for out of bound field points (WFI)

### DIFF
--- a/webbpsf/tests/test_wfirst.py
+++ b/webbpsf/tests/test_wfirst.py
@@ -104,17 +104,10 @@ def test_WFI_limits_interpolation_range():
     wfi = wfirst.WFI()
     det = wfi._detectors['SCA01']
     det.get_aberration_terms(1.29e-6)
+
     det.field_position = (0, 0)
-    with pytest.raises(RuntimeError) as excinfo:
-        det.get_aberration_terms(1.29e-6)
-    assert 'out-of-bounds field point' in str(excinfo.value), (
-        "FieldDependentAberration did not error on out-of-bounds field point"
-    )
-    with pytest.raises(RuntimeError) as excinfo:
-        det.get_aberration_terms(1.29e-6)
-    assert 'out-of-bounds field point' in str(excinfo.value), (
-        "FieldDependentAberration did not error on out-of-bounds field point"
-    )
+    det.get_aberration_terms(1.29e-6)
+
     det.field_position = (2048, 2048)
 
     # Test the get_aberration_terms function uses approximated wavelength when

--- a/webbpsf/wfirst.py
+++ b/webbpsf/wfirst.py
@@ -70,9 +70,9 @@ class WavelengthDependenceInterpolator(object):
                 if isinstance(wavelength, u.Quantity):
                     wavelength = wavelength.to(u.m).value
                 wavelength_closest = np.clip(wavelength, np.min(self._wavelengths), np.max(self._wavelengths))
-                _log.warn("Attempted to get aberrations at wavelength {:.2g} "
-                          "outside the range of the reference data; clipping to closest wavelength {:.2g}".format(
-                    wavelength, wavelength_closest))
+                _log.warning("Attempted to get aberrations at wavelength {:.2g} "
+                             "outside the range of the reference data; clipping to closest wavelength {:.2g}".format(
+                             wavelength, wavelength_closest))
 
                 aberration_terms = griddata(self._wavelengths, self._aberration_terms, wavelength_closest,
                                             method='linear')


### PR DESCRIPTION
closes #296 
Use nearest field point's aberration terms when the user selects a field position outside of the interpolatable area. 