### PR TITLE
Remove units option from get_opd

### DIFF
--- a/webbpsf/wfirst.py
+++ b/webbpsf/wfirst.py
@@ -106,7 +106,7 @@ class FieldDependentAberration(poppy.ZernikeWFE):
             interp_order=interp_order
         )
 
-    def get_opd(self, wave, units='meters'):
+    def get_opd(self, wave):
         """Set the Zernike coefficients (for ZernikeWFE.getOPD) based
         on the wavelength of the incoming wavefront and the pixel
         position
@@ -116,7 +116,7 @@ class FieldDependentAberration(poppy.ZernikeWFE):
         else:
             wavelength = wave.wavelength
         self.coefficients = wavelength * self.get_aberration_terms(wavelength)
-        return super(FieldDependentAberration, self).get_opd(wave, units=units)
+        return super(FieldDependentAberration, self).get_opd(wave)
 
     @property
     def field_position(self):


### PR DESCRIPTION
Follow up to changes made in poppy here https://github.com/spacetelescope/poppy/pull/322 . There’s a `get_opd` method in webbpsf that needs to take these changes into account. Fixes 2 tests in `test_wfirst.py` which were failing