### PR TITLE
improve WLP4 handling, and move_sur function

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,6 @@
 include README.rst
 recursive-include  webbpsf/otelm *.fits *.txt
+recursive-include webbpsf/tests/surs *.xml
 
 recursive-include webbpsf *.pyx *.c
 include setup.cfg

--- a/webbpsf/tests/surs/example_coarse_phasing_N2019041204_sur.xml
+++ b/webbpsf/tests/surs/example_coarse_phasing_N2019041204_sur.xml
@@ -1,0 +1,177 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+<SEGMENT_UPDATE_REQUEST creator="test" date="2019-04-12" operational="false" time="12:32:00.786" version="1.12" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="test">
+
+  <CONFIGURATION_NAME>test</CONFIGURATION_NAME>
+
+  <CORRECTION_ID>N2019012345</CORRECTION_ID>
+
+  <GROUP id="1">
+    <UPDATE absolute="false" coord="local" id="1" seg_id="A1-1" stage_type="fine_only" type="pose">
+      <X_TRANS units="meters">0.0000000000000000E+00</X_TRANS>
+      <Y_TRANS units="meters">0.0000000000000000E+00</Y_TRANS>
+      <PISTON units="meters">3.0000000000000001E-06</PISTON>
+      <X_TILT units="radians">0.0000000000000000E+00</X_TILT>
+      <Y_TILT units="radians">0.0000000000000000E+00</Y_TILT>
+      <CLOCK units="radians">0.0000000000000000E+00</CLOCK>
+    </UPDATE>
+    <UPDATE absolute="false" coord="local" id="2" seg_id="A2-2" stage_type="fine_only" type="pose">
+      <X_TRANS units="meters">0.0000000000000000E+00</X_TRANS>
+      <Y_TRANS units="meters">0.0000000000000000E+00</Y_TRANS>
+      <PISTON units="meters">3.0000000000000001E-06</PISTON>
+      <X_TILT units="radians">0.0000000000000000E+00</X_TILT>
+      <Y_TILT units="radians">0.0000000000000000E+00</Y_TILT>
+      <CLOCK units="radians">0.0000000000000000E+00</CLOCK>
+    </UPDATE>
+    <UPDATE absolute="false" coord="local" id="3" seg_id="A3-3" stage_type="fine_only" type="pose">
+      <X_TRANS units="meters">0.0000000000000000E+00</X_TRANS>
+      <Y_TRANS units="meters">0.0000000000000000E+00</Y_TRANS>
+      <PISTON units="meters">3.0000000000000001E-06</PISTON>
+      <X_TILT units="radians">0.0000000000000000E+00</X_TILT>
+      <Y_TILT units="radians">0.0000000000000000E+00</Y_TILT>
+      <CLOCK units="radians">0.0000000000000000E+00</CLOCK>
+    </UPDATE>
+    <UPDATE absolute="false" coord="local" id="4" seg_id="A4-4" stage_type="fine_only" type="pose">
+      <X_TRANS units="meters">0.0000000000000000E+00</X_TRANS>
+      <Y_TRANS units="meters">0.0000000000000000E+00</Y_TRANS>
+      <PISTON units="meters">3.0000000000000001E-06</PISTON>
+      <X_TILT units="radians">0.0000000000000000E+00</X_TILT>
+      <Y_TILT units="radians">0.0000000000000000E+00</Y_TILT>
+      <CLOCK units="radians">0.0000000000000000E+00</CLOCK>
+    </UPDATE>
+    <UPDATE absolute="false" coord="local" id="5" seg_id="A5-5" stage_type="fine_only" type="pose">
+      <X_TRANS units="meters">0.0000000000000000E+00</X_TRANS>
+      <Y_TRANS units="meters">0.0000000000000000E+00</Y_TRANS>
+      <PISTON units="meters">3.0000000000000001E-06</PISTON>
+      <X_TILT units="radians">0.0000000000000000E+00</X_TILT>
+      <Y_TILT units="radians">0.0000000000000000E+00</Y_TILT>
+      <CLOCK units="radians">0.0000000000000000E+00</CLOCK>
+    </UPDATE>
+    <UPDATE absolute="false" coord="local" id="6" seg_id="A6-6" stage_type="fine_only" type="pose">
+      <X_TRANS units="meters">0.0000000000000000E+00</X_TRANS>
+      <Y_TRANS units="meters">0.0000000000000000E+00</Y_TRANS>
+      <PISTON units="meters">3.0000000000000001E-06</PISTON>
+      <X_TILT units="radians">0.0000000000000000E+00</X_TILT>
+      <Y_TILT units="radians">0.0000000000000000E+00</Y_TILT>
+      <CLOCK units="radians">0.0000000000000000E+00</CLOCK>
+    </UPDATE>
+    <UPDATE absolute="false" coord="local" id="7" seg_id="C2-10" stage_type="fine_only" type="pose">
+      <X_TRANS units="meters">0.0000000000000000E+00</X_TRANS>
+      <Y_TRANS units="meters">0.0000000000000000E+00</Y_TRANS>
+      <PISTON units="meters">3.0000000000000001E-06</PISTON>
+      <X_TILT units="radians">0.0000000000000000E+00</X_TILT>
+      <Y_TILT units="radians">0.0000000000000000E+00</Y_TILT>
+      <CLOCK units="radians">0.0000000000000000E+00</CLOCK>
+    </UPDATE>
+    <UPDATE absolute="false" coord="local" id="8" seg_id="C5-16" stage_type="fine_only" type="pose">
+      <X_TRANS units="meters">0.0000000000000000E+00</X_TRANS>
+      <Y_TRANS units="meters">0.0000000000000000E+00</Y_TRANS>
+      <PISTON units="meters">3.0000000000000001E-06</PISTON>
+      <X_TILT units="radians">0.0000000000000000E+00</X_TILT>
+      <Y_TILT units="radians">0.0000000000000000E+00</Y_TILT>
+      <CLOCK units="radians">0.0000000000000000E+00</CLOCK>
+    </UPDATE>
+  </GROUP>
+
+  <GROUP id="2">
+    <UPDATE absolute="false" coord="local" id="1" seg_id="C2-10" stage_type="fine_only" type="pose">
+      <X_TRANS units="meters">0.0000000000000000E+00</X_TRANS>
+      <Y_TRANS units="meters">0.0000000000000000E+00</Y_TRANS>
+      <PISTON units="meters">-3.0000000000000001E-06</PISTON>
+      <X_TILT units="radians">0.0000000000000000E+00</X_TILT>
+      <Y_TILT units="radians">0.0000000000000000E+00</Y_TILT>
+      <CLOCK units="radians">0.0000000000000000E+00</CLOCK>
+    </UPDATE>
+    <UPDATE absolute="false" coord="local" id="2" seg_id="C5-16" stage_type="fine_only" type="pose">
+      <X_TRANS units="meters">0.0000000000000000E+00</X_TRANS>
+      <Y_TRANS units="meters">0.0000000000000000E+00</Y_TRANS>
+      <PISTON units="meters">-3.0000000000000001E-06</PISTON>
+      <X_TILT units="radians">0.0000000000000000E+00</X_TILT>
+      <Y_TILT units="radians">0.0000000000000000E+00</Y_TILT>
+      <CLOCK units="radians">0.0000000000000000E+00</CLOCK>
+    </UPDATE>
+    <UPDATE absolute="false" coord="local" id="3" seg_id="C1-8" stage_type="fine_only" type="pose">
+      <X_TRANS units="meters">0.0000000000000000E+00</X_TRANS>
+      <Y_TRANS units="meters">0.0000000000000000E+00</Y_TRANS>
+      <PISTON units="meters">3.0000000000000001E-06</PISTON>
+      <X_TILT units="radians">0.0000000000000000E+00</X_TILT>
+      <Y_TILT units="radians">0.0000000000000000E+00</Y_TILT>
+      <CLOCK units="radians">0.0000000000000000E+00</CLOCK>
+    </UPDATE>
+    <UPDATE absolute="false" coord="local" id="4" seg_id="C4-14" stage_type="fine_only" type="pose">
+      <X_TRANS units="meters">0.0000000000000000E+00</X_TRANS>
+      <Y_TRANS units="meters">0.0000000000000000E+00</Y_TRANS>
+      <PISTON units="meters">3.0000000000000001E-06</PISTON>
+      <X_TILT units="radians">0.0000000000000000E+00</X_TILT>
+      <Y_TILT units="radians">0.0000000000000000E+00</Y_TILT>
+      <CLOCK units="radians">0.0000000000000000E+00</CLOCK>
+    </UPDATE>
+  </GROUP>
+
+  <GROUP id="3">
+    <UPDATE absolute="false" coord="local" id="1" seg_id="A1-1" stage_type="fine_only" type="pose">
+      <X_TRANS units="meters">0.0000000000000000E+00</X_TRANS>
+      <Y_TRANS units="meters">0.0000000000000000E+00</Y_TRANS>
+      <PISTON units="meters">-3.0000000000000001E-06</PISTON>
+      <X_TILT units="radians">0.0000000000000000E+00</X_TILT>
+      <Y_TILT units="radians">0.0000000000000000E+00</Y_TILT>
+      <CLOCK units="radians">0.0000000000000000E+00</CLOCK>
+    </UPDATE>
+    <UPDATE absolute="false" coord="local" id="2" seg_id="A2-2" stage_type="fine_only" type="pose">
+      <X_TRANS units="meters">0.0000000000000000E+00</X_TRANS>
+      <Y_TRANS units="meters">0.0000000000000000E+00</Y_TRANS>
+      <PISTON units="meters">-3.0000000000000001E-06</PISTON>
+      <X_TILT units="radians">0.0000000000000000E+00</X_TILT>
+      <Y_TILT units="radians">0.0000000000000000E+00</Y_TILT>
+      <CLOCK units="radians">0.0000000000000000E+00</CLOCK>
+    </UPDATE>
+    <UPDATE absolute="false" coord="local" id="3" seg_id="A3-3" stage_type="fine_only" type="pose">
+      <X_TRANS units="meters">0.0000000000000000E+00</X_TRANS>
+      <Y_TRANS units="meters">0.0000000000000000E+00</Y_TRANS>
+      <PISTON units="meters">-3.0000000000000001E-06</PISTON>
+      <X_TILT units="radians">0.0000000000000000E+00</X_TILT>
+      <Y_TILT units="radians">0.0000000000000000E+00</Y_TILT>
+      <CLOCK units="radians">0.0000000000000000E+00</CLOCK>
+    </UPDATE>
+    <UPDATE absolute="false" coord="local" id="4" seg_id="A4-4" stage_type="fine_only" type="pose">
+      <X_TRANS units="meters">0.0000000000000000E+00</X_TRANS>
+      <Y_TRANS units="meters">0.0000000000000000E+00</Y_TRANS>
+      <PISTON units="meters">-3.0000000000000001E-06</PISTON>
+      <X_TILT units="radians">0.0000000000000000E+00</X_TILT>
+      <Y_TILT units="radians">0.0000000000000000E+00</Y_TILT>
+      <CLOCK units="radians">0.0000000000000000E+00</CLOCK>
+    </UPDATE>
+    <UPDATE absolute="false" coord="local" id="5" seg_id="A5-5" stage_type="fine_only" type="pose">
+      <X_TRANS units="meters">0.0000000000000000E+00</X_TRANS>
+      <Y_TRANS units="meters">0.0000000000000000E+00</Y_TRANS>
+      <PISTON units="meters">-3.0000000000000001E-06</PISTON>
+      <X_TILT units="radians">0.0000000000000000E+00</X_TILT>
+      <Y_TILT units="radians">0.0000000000000000E+00</Y_TILT>
+      <CLOCK units="radians">0.0000000000000000E+00</CLOCK>
+    </UPDATE>
+    <UPDATE absolute="false" coord="local" id="6" seg_id="A6-6" stage_type="fine_only" type="pose">
+      <X_TRANS units="meters">0.0000000000000000E+00</X_TRANS>
+      <Y_TRANS units="meters">0.0000000000000000E+00</Y_TRANS>
+      <PISTON units="meters">-3.0000000000000001E-06</PISTON>
+      <X_TILT units="radians">0.0000000000000000E+00</X_TILT>
+      <Y_TILT units="radians">0.0000000000000000E+00</Y_TILT>
+      <CLOCK units="radians">0.0000000000000000E+00</CLOCK>
+    </UPDATE>
+    <UPDATE absolute="false" coord="local" id="7" seg_id="C1-8" stage_type="fine_only" type="pose">
+      <X_TRANS units="meters">0.0000000000000000E+00</X_TRANS>
+      <Y_TRANS units="meters">0.0000000000000000E+00</Y_TRANS>
+      <PISTON units="meters">-3.0000000000000001E-06</PISTON>
+      <X_TILT units="radians">0.0000000000000000E+00</X_TILT>
+      <Y_TILT units="radians">0.0000000000000000E+00</Y_TILT>
+      <CLOCK units="radians">0.0000000000000000E+00</CLOCK>
+    </UPDATE>
+    <UPDATE absolute="false" coord="local" id="8" seg_id="C4-14" stage_type="fine_only" type="pose">
+      <X_TRANS units="meters">0.0000000000000000E+00</X_TRANS>
+      <Y_TRANS units="meters">0.0000000000000000E+00</Y_TRANS>
+      <PISTON units="meters">-3.0000000000000001E-06</PISTON>
+      <X_TILT units="radians">0.0000000000000000E+00</X_TILT>
+      <Y_TILT units="radians">0.0000000000000000E+00</Y_TILT>
+      <CLOCK units="radians">0.0000000000000000E+00</CLOCK>
+    </UPDATE>
+  </GROUP>
+
+</SEGMENT_UPDATE_REQUEST>

--- a/webbpsf/tests/surs/example_fine_phasing_R201902010S_sur.xml
+++ b/webbpsf/tests/surs/example_fine_phasing_R201902010S_sur.xml
@@ -1,0 +1,155 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+<SEGMENT_UPDATE_REQUEST creator="test" date="2019-02-01" operational="false" time="21:21:36.350" version="1.12" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="test">
+
+  <CONFIGURATION_NAME>test</CONFIGURATION_NAME>
+
+  <CORRECTION_ID>R2019012345</CORRECTION_ID>
+
+  <GROUP id="1">
+    <UPDATE absolute="false" coord="local" id="1" seg_id="A1-1" stage_type="fine_only" type="pose">
+      <X_TRANS units="meters">0.0000000000000000E+00</X_TRANS>
+      <Y_TRANS units="meters">0.0000000000000000E+00</Y_TRANS>
+      <PISTON units="meters">0.0000000000000000E+00</PISTON>
+      <X_TILT units="radians">6.4614087343215947E-08</X_TILT>
+      <Y_TILT units="radians">-6.2545321881771087E-08</Y_TILT>
+      <CLOCK units="radians">0.0000000000000000E+00</CLOCK>
+    </UPDATE>
+    <UPDATE absolute="false" coord="local" id="2" seg_id="A2-2" stage_type="fine_only" type="pose">
+      <X_TRANS units="meters">0.0000000000000000E+00</X_TRANS>
+      <Y_TRANS units="meters">0.0000000000000000E+00</Y_TRANS>
+      <PISTON units="meters">0.0000000000000000E+00</PISTON>
+      <X_TILT units="radians">6.4073510468006129E-08</X_TILT>
+      <Y_TILT units="radians">1.6736552119255065E-08</Y_TILT>
+      <CLOCK units="radians">0.0000000000000000E+00</CLOCK>
+    </UPDATE>
+    <UPDATE absolute="false" coord="local" id="3" seg_id="A3-3" stage_type="fine_only" type="pose">
+      <X_TRANS units="meters">0.0000000000000000E+00</X_TRANS>
+      <Y_TRANS units="meters">0.0000000000000000E+00</Y_TRANS>
+      <PISTON units="meters">0.0000000000000000E+00</PISTON>
+      <X_TILT units="radians">4.7173835337162019E-09</X_TILT>
+      <Y_TILT units="radians">9.7886100411415098E-08</Y_TILT>
+      <CLOCK units="radians">0.0000000000000000E+00</CLOCK>
+    </UPDATE>
+    <UPDATE absolute="false" coord="local" id="4" seg_id="A4-4" stage_type="fine_only" type="pose">
+      <X_TRANS units="meters">0.0000000000000000E+00</X_TRANS>
+      <Y_TRANS units="meters">0.0000000000000000E+00</Y_TRANS>
+      <PISTON units="meters">0.0000000000000000E+00</PISTON>
+      <X_TILT units="radians">-6.8878024816513064E-08</X_TILT>
+      <Y_TILT units="radians">8.2267031073570249E-08</Y_TILT>
+      <CLOCK units="radians">0.0000000000000000E+00</CLOCK>
+    </UPDATE>
+    <UPDATE absolute="false" coord="local" id="5" seg_id="A5-5" stage_type="fine_only" type="pose">
+      <X_TRANS units="meters">0.0000000000000000E+00</X_TRANS>
+      <Y_TRANS units="meters">0.0000000000000000E+00</Y_TRANS>
+      <PISTON units="meters">0.0000000000000000E+00</PISTON>
+      <X_TILT units="radians">-7.5460448861122135E-08</X_TILT>
+      <Y_TILT units="radians">-4.1536521166563035E-09</Y_TILT>
+      <CLOCK units="radians">0.0000000000000000E+00</CLOCK>
+    </UPDATE>
+    <UPDATE absolute="false" coord="local" id="6" seg_id="A6-6" stage_type="fine_only" type="pose">
+      <X_TRANS units="meters">0.0000000000000000E+00</X_TRANS>
+      <Y_TRANS units="meters">0.0000000000000000E+00</Y_TRANS>
+      <PISTON units="meters">0.0000000000000000E+00</PISTON>
+      <X_TILT units="radians">-1.0756971314549446E-08</X_TILT>
+      <Y_TILT units="radians">-7.6345570385456083E-08</Y_TILT>
+      <CLOCK units="radians">0.0000000000000000E+00</CLOCK>
+    </UPDATE>
+    <UPDATE absolute="false" coord="local" id="7" seg_id="B1-7" stage_type="fine_only" type="pose">
+      <X_TRANS units="meters">0.0000000000000000E+00</X_TRANS>
+      <Y_TRANS units="meters">0.0000000000000000E+00</Y_TRANS>
+      <PISTON units="meters">0.0000000000000000E+00</PISTON>
+      <X_TILT units="radians">-7.5268104672431944E-08</X_TILT>
+      <Y_TILT units="radians">4.6273376792669295E-08</Y_TILT>
+      <CLOCK units="radians">0.0000000000000000E+00</CLOCK>
+    </UPDATE>
+    <UPDATE absolute="false" coord="local" id="8" seg_id="C1-8" stage_type="fine_only" type="pose">
+      <X_TRANS units="meters">0.0000000000000000E+00</X_TRANS>
+      <Y_TRANS units="meters">0.0000000000000000E+00</Y_TRANS>
+      <PISTON units="meters">0.0000000000000000E+00</PISTON>
+      <X_TILT units="radians">2.6988059282302855E-08</X_TILT>
+      <Y_TILT units="radians">4.0546979755163194E-08</Y_TILT>
+      <CLOCK units="radians">0.0000000000000000E+00</CLOCK>
+    </UPDATE>
+    <UPDATE absolute="false" coord="local" id="9" seg_id="B2-9" stage_type="fine_only" type="pose">
+      <X_TRANS units="meters">0.0000000000000000E+00</X_TRANS>
+      <Y_TRANS units="meters">0.0000000000000000E+00</Y_TRANS>
+      <PISTON units="meters">0.0000000000000000E+00</PISTON>
+      <X_TILT units="radians">-7.6866626739501958E-08</X_TILT>
+      <Y_TILT units="radians">-2.5779042392969133E-08</Y_TILT>
+      <CLOCK units="radians">0.0000000000000000E+00</CLOCK>
+    </UPDATE>
+    <UPDATE absolute="false" coord="local" id="10" seg_id="C2-10" stage_type="fine_only" type="pose">
+      <X_TRANS units="meters">0.0000000000000000E+00</X_TRANS>
+      <Y_TRANS units="meters">0.0000000000000000E+00</Y_TRANS>
+      <PISTON units="meters">0.0000000000000000E+00</PISTON>
+      <X_TILT units="radians">1.0784910917282104E-06</X_TILT>
+      <Y_TILT units="radians">-9.1055190563201907E-07</Y_TILT>
+      <CLOCK units="radians">0.0000000000000000E+00</CLOCK>
+    </UPDATE>
+    <UPDATE absolute="false" coord="local" id="11" seg_id="B3-11" stage_type="fine_only" type="pose">
+      <X_TRANS units="meters">0.0000000000000000E+00</X_TRANS>
+      <Y_TRANS units="meters">0.0000000000000000E+00</Y_TRANS>
+      <PISTON units="meters">0.0000000000000000E+00</PISTON>
+      <X_TILT units="radians">-1.6003552824258804E-08</X_TILT>
+      <Y_TILT units="radians">-7.4931994080543520E-08</Y_TILT>
+      <CLOCK units="radians">0.0000000000000000E+00</CLOCK>
+    </UPDATE>
+    <UPDATE absolute="false" coord="local" id="12" seg_id="C3-12" stage_type="fine_only" type="pose">
+      <X_TRANS units="meters">0.0000000000000000E+00</X_TRANS>
+      <Y_TRANS units="meters">0.0000000000000000E+00</Y_TRANS>
+      <PISTON units="meters">0.0000000000000000E+00</PISTON>
+      <X_TILT units="radians">-8.4864765405654912E-08</X_TILT>
+      <Y_TILT units="radians">-6.7864134907722475E-08</Y_TILT>
+      <CLOCK units="radians">0.0000000000000000E+00</CLOCK>
+    </UPDATE>
+    <UPDATE absolute="false" coord="local" id="13" seg_id="B4-13" stage_type="fine_only" type="pose">
+      <X_TRANS units="meters">0.0000000000000000E+00</X_TRANS>
+      <Y_TRANS units="meters">0.0000000000000000E+00</Y_TRANS>
+      <PISTON units="meters">0.0000000000000000E+00</PISTON>
+      <X_TILT units="radians">5.9382956475019454E-08</X_TILT>
+      <Y_TILT units="radians">-4.6165265142917631E-08</Y_TILT>
+      <CLOCK units="radians">0.0000000000000000E+00</CLOCK>
+    </UPDATE>
+    <UPDATE absolute="false" coord="local" id="14" seg_id="C4-14" stage_type="fine_only" type="pose">
+      <X_TRANS units="meters">0.0000000000000000E+00</X_TRANS>
+      <Y_TRANS units="meters">0.0000000000000000E+00</Y_TRANS>
+      <PISTON units="meters">0.0000000000000000E+00</PISTON>
+      <X_TILT units="radians">-1.6762424260377883E-08</X_TILT>
+      <Y_TILT units="radians">-1.3380146026611329E-07</Y_TILT>
+      <CLOCK units="radians">0.0000000000000000E+00</CLOCK>
+    </UPDATE>
+    <UPDATE absolute="false" coord="local" id="15" seg_id="B5-15" stage_type="fine_only" type="pose">
+      <X_TRANS units="meters">0.0000000000000000E+00</X_TRANS>
+      <Y_TRANS units="meters">0.0000000000000000E+00</Y_TRANS>
+      <PISTON units="meters">0.0000000000000000E+00</PISTON>
+      <X_TILT units="radians">6.6069960594177250E-08</X_TILT>
+      <Y_TILT units="radians">2.7054773643612863E-08</Y_TILT>
+      <CLOCK units="radians">0.0000000000000000E+00</CLOCK>
+    </UPDATE>
+    <UPDATE absolute="false" coord="local" id="16" seg_id="C5-16" stage_type="fine_only" type="pose">
+      <X_TRANS units="meters">0.0000000000000000E+00</X_TRANS>
+      <Y_TRANS units="meters">0.0000000000000000E+00</Y_TRANS>
+      <PISTON units="meters">0.0000000000000000E+00</PISTON>
+      <X_TILT units="radians">6.2971808016300204E-08</X_TILT>
+      <Y_TILT units="radians">-4.5519601553678513E-08</Y_TILT>
+      <CLOCK units="radians">0.0000000000000000E+00</CLOCK>
+    </UPDATE>
+    <UPDATE absolute="false" coord="local" id="17" seg_id="B6-17" stage_type="fine_only" type="pose">
+      <X_TRANS units="meters">0.0000000000000000E+00</X_TRANS>
+      <Y_TRANS units="meters">0.0000000000000000E+00</Y_TRANS>
+      <PISTON units="meters">0.0000000000000000E+00</PISTON>
+      <X_TILT units="radians">2.3537907749414444E-08</X_TILT>
+      <Y_TILT units="radians">8.6295977234840391E-08</Y_TILT>
+      <CLOCK units="radians">0.0000000000000000E+00</CLOCK>
+    </UPDATE>
+    <UPDATE absolute="false" coord="local" id="18" seg_id="C6-18" stage_type="fine_only" type="pose">
+      <X_TRANS units="meters">0.0000000000000000E+00</X_TRANS>
+      <Y_TRANS units="meters">0.0000000000000000E+00</Y_TRANS>
+      <PISTON units="meters">0.0000000000000000E+00</PISTON>
+      <X_TILT units="radians">5.8064613491296768E-08</X_TILT>
+      <Y_TILT units="radians">1.2913662940263748E-08</Y_TILT>
+      <CLOCK units="radians">0.0000000000000000E+00</CLOCK>
+    </UPDATE>
+  </GROUP>
+
+</SEGMENT_UPDATE_REQUEST>

--- a/webbpsf/tests/surs/example_global_alignment_N201902010F_sur.xml
+++ b/webbpsf/tests/surs/example_global_alignment_N201902010F_sur.xml
@@ -1,0 +1,318 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+<SEGMENT_UPDATE_REQUEST creator="test" date="2019-02-01" operational="False" time="14:52:43.882" version="1.12" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="segment_update_request.xsd">
+
+  <CONFIGURATION_NAME>test</CONFIGURATION_NAME>
+
+  <CORRECTION_ID>N2019123456</CORRECTION_ID>
+
+  <GROUP id="1">
+    <UPDATE absolute="false" coord="local" id="1" seg_id="SM-19" stage_type="none" type="pose">
+      <X_TRANS units="meters">0.0000000000000000E+00</X_TRANS>
+      <Y_TRANS units="meters">0.0000000000000000E+00</Y_TRANS>
+      <PISTON units="meters">3.9999996948242186E-04</PISTON>
+      <X_TILT units="radians">0.0000000000000000E+00</X_TILT>
+      <Y_TILT units="radians">0.0000000000000000E+00</Y_TILT>
+      <CLOCK units="radians">0.0000000000000000E+00</CLOCK>
+    </UPDATE>
+    <UPDATE absolute="false" coord="local" id="2" seg_id="A1-1" stage_type="none" type="pose">
+      <X_TRANS units="meters">0.0000000000000000E+00</X_TRANS>
+      <Y_TRANS units="meters">0.0000000000000000E+00</Y_TRANS>
+      <PISTON units="meters">-0.0000000000000000E+00</PISTON>
+      <X_TILT units="radians">-4.2065963745117191E-06</X_TILT>
+      <Y_TILT units="radians">4.4965073466300966E-09</Y_TILT>
+      <CLOCK units="radians">0.0000000000000000E+00</CLOCK>
+    </UPDATE>
+    <UPDATE absolute="false" coord="local" id="3" seg_id="A2-2" stage_type="none" type="pose">
+      <X_TRANS units="meters">0.0000000000000000E+00</X_TRANS>
+      <Y_TRANS units="meters">0.0000000000000000E+00</Y_TRANS>
+      <PISTON units="meters">-0.0000000000000000E+00</PISTON>
+      <X_TILT units="radians">-4.2008914947509766E-06</X_TILT>
+      <Y_TILT units="radians">-1.3926506042480468E-08</Y_TILT>
+      <CLOCK units="radians">0.0000000000000000E+00</CLOCK>
+    </UPDATE>
+    <UPDATE absolute="false" coord="local" id="4" seg_id="A3-3" stage_type="none" type="pose">
+      <X_TRANS units="meters">0.0000000000000000E+00</X_TRANS>
+      <Y_TRANS units="meters">0.0000000000000000E+00</Y_TRANS>
+      <PISTON units="meters">-0.0000000000000000E+00</PISTON>
+      <X_TILT units="radians">-4.2232389450073241E-06</X_TILT>
+      <Y_TILT units="radians">-4.6306610107421877E-08</Y_TILT>
+      <CLOCK units="radians">0.0000000000000000E+00</CLOCK>
+    </UPDATE>
+    <UPDATE absolute="false" coord="local" id="5" seg_id="A4-4" stage_type="none" type="pose">
+      <X_TRANS units="meters">0.0000000000000000E+00</X_TRANS>
+      <Y_TRANS units="meters">0.0000000000000000E+00</Y_TRANS>
+      <PISTON units="meters">-0.0000000000000000E+00</PISTON>
+      <X_TILT units="radians">-4.2590227127075194E-06</X_TILT>
+      <Y_TILT units="radians">-1.3179928064346313E-09</Y_TILT>
+      <CLOCK units="radians">0.0000000000000000E+00</CLOCK>
+    </UPDATE>
+    <UPDATE absolute="false" coord="local" id="6" seg_id="A5-5" stage_type="none" type="pose">
+      <X_TRANS units="meters">0.0000000000000000E+00</X_TRANS>
+      <Y_TRANS units="meters">0.0000000000000000E+00</Y_TRANS>
+      <PISTON units="meters">-0.0000000000000000E+00</PISTON>
+      <X_TILT units="radians">-4.2216944694519047E-06</X_TILT>
+      <Y_TILT units="radians">4.8401713371276858E-08</Y_TILT>
+      <CLOCK units="radians">0.0000000000000000E+00</CLOCK>
+    </UPDATE>
+    <UPDATE absolute="false" coord="local" id="7" seg_id="A6-6" stage_type="none" type="pose">
+      <X_TRANS units="meters">0.0000000000000000E+00</X_TRANS>
+      <Y_TRANS units="meters">0.0000000000000000E+00</Y_TRANS>
+      <PISTON units="meters">-0.0000000000000000E+00</PISTON>
+      <X_TILT units="radians">-4.2036099433898927E-06</X_TILT>
+      <Y_TILT units="radians">2.0043969154357912E-08</Y_TILT>
+      <CLOCK units="radians">0.0000000000000000E+00</CLOCK>
+    </UPDATE>
+    <UPDATE absolute="false" coord="local" id="8" seg_id="B1-7" stage_type="none" type="pose">
+      <X_TRANS units="meters">0.0000000000000000E+00</X_TRANS>
+      <Y_TRANS units="meters">0.0000000000000000E+00</Y_TRANS>
+      <PISTON units="meters">0.0000000000000000E+00</PISTON>
+      <X_TILT units="radians">8.0857458114624027E-06</X_TILT>
+      <Y_TILT units="radians">-5.3757429122924800E-10</Y_TILT>
+      <CLOCK units="radians">0.0000000000000000E+00</CLOCK>
+    </UPDATE>
+    <UPDATE absolute="false" coord="local" id="9" seg_id="C1-8" stage_type="none" type="pose">
+      <X_TRANS units="meters">0.0000000000000000E+00</X_TRANS>
+      <Y_TRANS units="meters">0.0000000000000000E+00</Y_TRANS>
+      <PISTON units="meters">0.0000000000000000E+00</PISTON>
+      <X_TILT units="radians">1.2953519821166992E-08</X_TILT>
+      <Y_TILT units="radians">-7.0859689712524410E-06</Y_TILT>
+      <CLOCK units="radians">0.0000000000000000E+00</CLOCK>
+    </UPDATE>
+    <UPDATE absolute="false" coord="local" id="10" seg_id="B2-9" stage_type="none" type="pose">
+      <X_TRANS units="meters">0.0000000000000000E+00</X_TRANS>
+      <Y_TRANS units="meters">0.0000000000000000E+00</Y_TRANS>
+      <PISTON units="meters">0.0000000000000000E+00</PISTON>
+      <X_TILT units="radians">8.0496959686279301E-06</X_TILT>
+      <Y_TILT units="radians">1.1325597763061523E-08</Y_TILT>
+      <CLOCK units="radians">0.0000000000000000E+00</CLOCK>
+    </UPDATE>
+    <UPDATE absolute="false" coord="local" id="11" seg_id="C2-10" stage_type="none" type="pose">
+      <X_TRANS units="meters">0.0000000000000000E+00</X_TRANS>
+      <Y_TRANS units="meters">0.0000000000000000E+00</Y_TRANS>
+      <PISTON units="meters">0.0000000000000000E+00</PISTON>
+      <X_TILT units="radians">1.4507606625556946E-08</X_TILT>
+      <Y_TILT units="radians">-7.0649585723876956E-06</Y_TILT>
+      <CLOCK units="radians">0.0000000000000000E+00</CLOCK>
+    </UPDATE>
+    <UPDATE absolute="false" coord="local" id="12" seg_id="B3-11" stage_type="none" type="pose">
+      <X_TRANS units="meters">0.0000000000000000E+00</X_TRANS>
+      <Y_TRANS units="meters">0.0000000000000000E+00</Y_TRANS>
+      <PISTON units="meters">0.0000000000000000E+00</PISTON>
+      <X_TILT units="radians">8.0289402008056635E-06</X_TILT>
+      <Y_TILT units="radians">2.3813486099243163E-08</Y_TILT>
+      <CLOCK units="radians">0.0000000000000000E+00</CLOCK>
+    </UPDATE>
+    <UPDATE absolute="false" coord="local" id="13" seg_id="C3-12" stage_type="none" type="pose">
+      <X_TRANS units="meters">0.0000000000000000E+00</X_TRANS>
+      <Y_TRANS units="meters">0.0000000000000000E+00</Y_TRANS>
+      <PISTON units="meters">0.0000000000000000E+00</PISTON>
+      <X_TILT units="radians">6.6792964935302738E-09</X_TILT>
+      <Y_TILT units="radians">-7.0690913200378417E-06</Y_TILT>
+      <CLOCK units="radians">0.0000000000000000E+00</CLOCK>
+    </UPDATE>
+    <UPDATE absolute="false" coord="local" id="14" seg_id="B4-13" stage_type="none" type="pose">
+      <X_TRANS units="meters">0.0000000000000000E+00</X_TRANS>
+      <Y_TRANS units="meters">0.0000000000000000E+00</Y_TRANS>
+      <PISTON units="meters">0.0000000000000000E+00</PISTON>
+      <X_TILT units="radians">8.0213842391967768E-06</X_TILT>
+      <Y_TILT units="radians">7.2790086269378659E-09</Y_TILT>
+      <CLOCK units="radians">0.0000000000000000E+00</CLOCK>
+    </UPDATE>
+    <UPDATE absolute="false" coord="local" id="15" seg_id="C4-14" stage_type="none" type="pose">
+      <X_TRANS units="meters">0.0000000000000000E+00</X_TRANS>
+      <Y_TRANS units="meters">0.0000000000000000E+00</Y_TRANS>
+      <PISTON units="meters">0.0000000000000000E+00</PISTON>
+      <X_TILT units="radians">-4.5888423919677735E-09</X_TILT>
+      <Y_TILT units="radians">-7.0598297119140625E-06</Y_TILT>
+      <CLOCK units="radians">0.0000000000000000E+00</CLOCK>
+    </UPDATE>
+    <UPDATE absolute="false" coord="local" id="16" seg_id="B5-15" stage_type="none" type="pose">
+      <X_TRANS units="meters">0.0000000000000000E+00</X_TRANS>
+      <Y_TRANS units="meters">0.0000000000000000E+00</Y_TRANS>
+      <PISTON units="meters">0.0000000000000000E+00</PISTON>
+      <X_TILT units="radians">8.0298767089843749E-06</X_TILT>
+      <Y_TILT units="radians">-2.2035837173461912E-08</Y_TILT>
+      <CLOCK units="radians">0.0000000000000000E+00</CLOCK>
+    </UPDATE>
+    <UPDATE absolute="false" coord="local" id="17" seg_id="C5-16" stage_type="none" type="pose">
+      <X_TRANS units="meters">0.0000000000000000E+00</X_TRANS>
+      <Y_TRANS units="meters">0.0000000000000000E+00</Y_TRANS>
+      <PISTON units="meters">0.0000000000000000E+00</PISTON>
+      <X_TILT units="radians">-2.1062970161437990E-08</X_TILT>
+      <Y_TILT units="radians">-7.0633387565612789E-06</Y_TILT>
+      <CLOCK units="radians">0.0000000000000000E+00</CLOCK>
+    </UPDATE>
+    <UPDATE absolute="false" coord="local" id="18" seg_id="B6-17" stage_type="none" type="pose">
+      <X_TRANS units="meters">0.0000000000000000E+00</X_TRANS>
+      <Y_TRANS units="meters">0.0000000000000000E+00</Y_TRANS>
+      <PISTON units="meters">0.0000000000000000E+00</PISTON>
+      <X_TILT units="radians">8.0481491088867180E-06</X_TILT>
+      <Y_TILT units="radians">-1.1859178543090820E-08</Y_TILT>
+      <CLOCK units="radians">0.0000000000000000E+00</CLOCK>
+    </UPDATE>
+    <UPDATE absolute="false" coord="local" id="19" seg_id="C6-18" stage_type="none" type="pose">
+      <X_TRANS units="meters">0.0000000000000000E+00</X_TRANS>
+      <Y_TRANS units="meters">0.0000000000000000E+00</Y_TRANS>
+      <PISTON units="meters">0.0000000000000000E+00</PISTON>
+      <X_TILT units="radians">-1.1661767959594726E-08</X_TILT>
+      <Y_TILT units="radians">-7.0939521789550781E-06</Y_TILT>
+      <CLOCK units="radians">0.0000000000000000E+00</CLOCK>
+    </UPDATE>
+  </GROUP>
+
+  <GROUP id="2">
+    <UPDATE absolute="false" coord="local" id="1" seg_id="SM-19" stage_type="none" type="pose">
+      <X_TRANS units="meters">0.0000000000000000E+00</X_TRANS>
+      <Y_TRANS units="meters">0.0000000000000000E+00</Y_TRANS>
+      <PISTON units="meters">-8.0000000000000004E-04</PISTON>
+      <X_TILT units="radians">0.0000000000000000E+00</X_TILT>
+      <Y_TILT units="radians">0.0000000000000000E+00</Y_TILT>
+      <CLOCK units="radians">0.0000000000000000E+00</CLOCK>
+    </UPDATE>
+    <UPDATE absolute="false" coord="local" id="2" seg_id="A1-1" stage_type="none" type="pose">
+      <X_TRANS units="meters">0.0000000000000000E+00</X_TRANS>
+      <Y_TRANS units="meters">0.0000000000000000E+00</Y_TRANS>
+      <PISTON units="meters">0.0000000000000000E+00</PISTON>
+      <X_TILT units="radians">8.4131937026977540E-06</X_TILT>
+      <Y_TILT units="radians">-8.9930146932601932E-09</Y_TILT>
+      <CLOCK units="radians">0.0000000000000000E+00</CLOCK>
+    </UPDATE>
+    <UPDATE absolute="false" coord="local" id="3" seg_id="A2-2" stage_type="none" type="pose">
+      <X_TRANS units="meters">0.0000000000000000E+00</X_TRANS>
+      <Y_TRANS units="meters">0.0000000000000000E+00</Y_TRANS>
+      <PISTON units="meters">0.0000000000000000E+00</PISTON>
+      <X_TILT units="radians">8.4017839431762689E-06</X_TILT>
+      <Y_TILT units="radians">2.7853012084960937E-08</Y_TILT>
+      <CLOCK units="radians">0.0000000000000000E+00</CLOCK>
+    </UPDATE>
+    <UPDATE absolute="false" coord="local" id="4" seg_id="A3-3" stage_type="none" type="pose">
+      <X_TRANS units="meters">0.0000000000000000E+00</X_TRANS>
+      <Y_TRANS units="meters">0.0000000000000000E+00</Y_TRANS>
+      <PISTON units="meters">0.0000000000000000E+00</PISTON>
+      <X_TILT units="radians">8.4464778900146482E-06</X_TILT>
+      <Y_TILT units="radians">9.2612743377685550E-08</Y_TILT>
+      <CLOCK units="radians">0.0000000000000000E+00</CLOCK>
+    </UPDATE>
+    <UPDATE absolute="false" coord="local" id="5" seg_id="A4-4" stage_type="none" type="pose">
+      <X_TRANS units="meters">0.0000000000000000E+00</X_TRANS>
+      <Y_TRANS units="meters">0.0000000000000000E+00</Y_TRANS>
+      <PISTON units="meters">0.0000000000000000E+00</PISTON>
+      <X_TILT units="radians">8.5180463790893563E-06</X_TILT>
+      <Y_TILT units="radians">2.6359856128692627E-09</Y_TILT>
+      <CLOCK units="radians">0.0000000000000000E+00</CLOCK>
+    </UPDATE>
+    <UPDATE absolute="false" coord="local" id="6" seg_id="A5-5" stage_type="none" type="pose">
+      <X_TRANS units="meters">0.0000000000000000E+00</X_TRANS>
+      <Y_TRANS units="meters">0.0000000000000000E+00</Y_TRANS>
+      <PISTON units="meters">0.0000000000000000E+00</PISTON>
+      <X_TILT units="radians">8.4433889389038094E-06</X_TILT>
+      <Y_TILT units="radians">-9.6803426742553716E-08</Y_TILT>
+      <CLOCK units="radians">0.0000000000000000E+00</CLOCK>
+    </UPDATE>
+    <UPDATE absolute="false" coord="local" id="7" seg_id="A6-6" stage_type="none" type="pose">
+      <X_TRANS units="meters">0.0000000000000000E+00</X_TRANS>
+      <Y_TRANS units="meters">0.0000000000000000E+00</Y_TRANS>
+      <PISTON units="meters">0.0000000000000000E+00</PISTON>
+      <X_TILT units="radians">8.4072208404541011E-06</X_TILT>
+      <Y_TILT units="radians">-4.0088176727294925E-08</Y_TILT>
+      <CLOCK units="radians">0.0000000000000000E+00</CLOCK>
+    </UPDATE>
+    <UPDATE absolute="false" coord="local" id="8" seg_id="B1-7" stage_type="none" type="pose">
+      <X_TRANS units="meters">0.0000000000000000E+00</X_TRANS>
+      <Y_TRANS units="meters">0.0000000000000000E+00</Y_TRANS>
+      <PISTON units="meters">-0.0000000000000000E+00</PISTON>
+      <X_TILT units="radians">-1.6171491622924805E-05</X_TILT>
+      <Y_TILT units="radians">1.0751485824584960E-09</Y_TILT>
+      <CLOCK units="radians">0.0000000000000000E+00</CLOCK>
+    </UPDATE>
+    <UPDATE absolute="false" coord="local" id="9" seg_id="C1-8" stage_type="none" type="pose">
+      <X_TRANS units="meters">0.0000000000000000E+00</X_TRANS>
+      <Y_TRANS units="meters">0.0000000000000000E+00</Y_TRANS>
+      <PISTON units="meters">-0.0000000000000000E+00</PISTON>
+      <X_TILT units="radians">-2.5907039642333983E-08</X_TILT>
+      <Y_TILT units="radians">1.4171938896179199E-05</Y_TILT>
+      <CLOCK units="radians">0.0000000000000000E+00</CLOCK>
+    </UPDATE>
+    <UPDATE absolute="false" coord="local" id="10" seg_id="B2-9" stage_type="none" type="pose">
+      <X_TRANS units="meters">0.0000000000000000E+00</X_TRANS>
+      <Y_TRANS units="meters">0.0000000000000000E+00</Y_TRANS>
+      <PISTON units="meters">-0.0000000000000000E+00</PISTON>
+      <X_TILT units="radians">-1.6099391937255860E-05</X_TILT>
+      <Y_TILT units="radians">-2.2650718688964845E-08</Y_TILT>
+      <CLOCK units="radians">0.0000000000000000E+00</CLOCK>
+    </UPDATE>
+    <UPDATE absolute="false" coord="local" id="11" seg_id="C2-10" stage_type="none" type="pose">
+      <X_TRANS units="meters">0.0000000000000000E+00</X_TRANS>
+      <Y_TRANS units="meters">0.0000000000000000E+00</Y_TRANS>
+      <PISTON units="meters">-0.0000000000000000E+00</PISTON>
+      <X_TILT units="radians">-2.9015213251113893E-08</X_TILT>
+      <Y_TILT units="radians">1.4129918098449707E-05</Y_TILT>
+      <CLOCK units="radians">0.0000000000000000E+00</CLOCK>
+    </UPDATE>
+    <UPDATE absolute="false" coord="local" id="12" seg_id="B3-11" stage_type="none" type="pose">
+      <X_TRANS units="meters">0.0000000000000000E+00</X_TRANS>
+      <Y_TRANS units="meters">0.0000000000000000E+00</Y_TRANS>
+      <PISTON units="meters">-0.0000000000000000E+00</PISTON>
+      <X_TILT units="radians">-1.6057882308959962E-05</X_TILT>
+      <Y_TILT units="radians">-4.7626495361328123E-08</Y_TILT>
+      <CLOCK units="radians">0.0000000000000000E+00</CLOCK>
+    </UPDATE>
+    <UPDATE absolute="false" coord="local" id="13" seg_id="C3-12" stage_type="none" type="pose">
+      <X_TRANS units="meters">0.0000000000000000E+00</X_TRANS>
+      <Y_TRANS units="meters">0.0000000000000000E+00</Y_TRANS>
+      <PISTON units="meters">-0.0000000000000000E+00</PISTON>
+      <X_TILT units="radians">-1.3358592987060548E-08</X_TILT>
+      <Y_TILT units="radians">1.4138183593750001E-05</Y_TILT>
+      <CLOCK units="radians">0.0000000000000000E+00</CLOCK>
+    </UPDATE>
+    <UPDATE absolute="false" coord="local" id="14" seg_id="B4-13" stage_type="none" type="pose">
+      <X_TRANS units="meters">0.0000000000000000E+00</X_TRANS>
+      <Y_TRANS units="meters">0.0000000000000000E+00</Y_TRANS>
+      <PISTON units="meters">-0.0000000000000000E+00</PISTON>
+      <X_TILT units="radians">-1.6042770385742188E-05</X_TILT>
+      <Y_TILT units="radians">-1.4558017253875732E-08</Y_TILT>
+      <CLOCK units="radians">0.0000000000000000E+00</CLOCK>
+    </UPDATE>
+    <UPDATE absolute="false" coord="local" id="15" seg_id="C4-14" stage_type="none" type="pose">
+      <X_TRANS units="meters">0.0000000000000000E+00</X_TRANS>
+      <Y_TRANS units="meters">0.0000000000000000E+00</Y_TRANS>
+      <PISTON units="meters">-0.0000000000000000E+00</PISTON>
+      <X_TILT units="radians">9.1781616210937506E-09</X_TILT>
+      <Y_TILT units="radians">1.4119659423828125E-05</Y_TILT>
+      <CLOCK units="radians">0.0000000000000000E+00</CLOCK>
+    </UPDATE>
+    <UPDATE absolute="false" coord="local" id="16" seg_id="B5-15" stage_type="none" type="pose">
+      <X_TRANS units="meters">0.0000000000000000E+00</X_TRANS>
+      <Y_TRANS units="meters">0.0000000000000000E+00</Y_TRANS>
+      <PISTON units="meters">-0.0000000000000000E+00</PISTON>
+      <X_TILT units="radians">-1.6059755325317381E-05</X_TILT>
+      <Y_TILT units="radians">4.4071674346923825E-08</Y_TILT>
+      <CLOCK units="radians">0.0000000000000000E+00</CLOCK>
+    </UPDATE>
+    <UPDATE absolute="false" coord="local" id="17" seg_id="C5-16" stage_type="none" type="pose">
+      <X_TRANS units="meters">0.0000000000000000E+00</X_TRANS>
+      <Y_TRANS units="meters">0.0000000000000000E+00</Y_TRANS>
+      <PISTON units="meters">-0.0000000000000000E+00</PISTON>
+      <X_TILT units="radians">4.2125970125198365E-08</X_TILT>
+      <Y_TILT units="radians">1.4126678466796875E-05</Y_TILT>
+      <CLOCK units="radians">0.0000000000000000E+00</CLOCK>
+    </UPDATE>
+    <UPDATE absolute="false" coord="local" id="18" seg_id="B6-17" stage_type="none" type="pose">
+      <X_TRANS units="meters">0.0000000000000000E+00</X_TRANS>
+      <Y_TRANS units="meters">0.0000000000000000E+00</Y_TRANS>
+      <PISTON units="meters">-0.0000000000000000E+00</PISTON>
+      <X_TILT units="radians">-1.6096300125122071E-05</X_TILT>
+      <Y_TILT units="radians">2.3718357086181641E-08</Y_TILT>
+      <CLOCK units="radians">0.0000000000000000E+00</CLOCK>
+    </UPDATE>
+    <UPDATE absolute="false" coord="local" id="19" seg_id="C6-18" stage_type="none" type="pose">
+      <X_TRANS units="meters">0.0000000000000000E+00</X_TRANS>
+      <Y_TRANS units="meters">0.0000000000000000E+00</Y_TRANS>
+      <PISTON units="meters">-0.0000000000000000E+00</PISTON>
+      <X_TILT units="radians">2.3323535919189452E-08</X_TILT>
+      <Y_TILT units="radians">1.4187906265258789E-05</Y_TILT>
+      <CLOCK units="radians">0.0000000000000000E+00</CLOCK>
+    </UPDATE>
+  </GROUP>
+
+</SEGMENT_UPDATE_REQUEST>

--- a/webbpsf/tests/surs/example_image_stacking_O201904110E_sur.xml
+++ b/webbpsf/tests/surs/example_image_stacking_O201904110E_sur.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+<SEGMENT_UPDATE_REQUEST creator="test" date="2019-04-11" operational="False" time="18:59:12.814" version="1.12" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="segment_update_request.xsd">
+
+  <CONFIGURATION_NAME>test</CONFIGURATION_NAME>
+
+  <CORRECTION_ID>O2019012345</CORRECTION_ID>
+
+  <GROUP id="1">
+    <UPDATE absolute="false" coord="local" id="1" seg_id="C1-8" stage_type="fine_only" type="pose">
+      <X_TRANS units="meters">0.0000000000000000E+00</X_TRANS>
+      <Y_TRANS units="meters">0.0000000000000000E+00</Y_TRANS>
+      <PISTON units="meters">0.0000000000000000E+00</PISTON>
+      <X_TILT units="radians">-2.0420534536242485E-08</X_TILT>
+      <Y_TILT units="radians">-3.3853948116302490E-06</Y_TILT>
+      <CLOCK units="radians">0.0000000000000000E+00</CLOCK>
+    </UPDATE>
+  </GROUP>
+
+  <GROUP id="2">
+    <UPDATE absolute="false" coord="local" id="1" seg_id="C2-10" stage_type="fine_only" type="pose">
+      <X_TRANS units="meters">0.0000000000000000E+00</X_TRANS>
+      <Y_TRANS units="meters">0.0000000000000000E+00</Y_TRANS>
+      <PISTON units="meters">0.0000000000000000E+00</PISTON>
+      <X_TILT units="radians">1.7032954096794128E-07</X_TILT>
+      <Y_TILT units="radians">-3.5671529769897462E-06</Y_TILT>
+      <CLOCK units="radians">0.0000000000000000E+00</CLOCK>
+    </UPDATE>
+  </GROUP>
+
+  <GROUP id="3">
+    <UPDATE absolute="false" coord="local" id="1" seg_id="C3-12" stage_type="fine_only" type="pose">
+      <X_TRANS units="meters">0.0000000000000000E+00</X_TRANS>
+      <Y_TRANS units="meters">0.0000000000000000E+00</Y_TRANS>
+      <PISTON units="meters">0.0000000000000000E+00</PISTON>
+      <X_TILT units="radians">1.7410469055175781E-07</X_TILT>
+      <Y_TILT units="radians">-3.5993640422821043E-06</Y_TILT>
+      <CLOCK units="radians">0.0000000000000000E+00</CLOCK>
+    </UPDATE>
+  </GROUP>
+
+  <GROUP id="4">
+    <UPDATE absolute="false" coord="local" id="1" seg_id="C4-14" stage_type="fine_only" type="pose">
+      <X_TRANS units="meters">0.0000000000000000E+00</X_TRANS>
+      <Y_TRANS units="meters">0.0000000000000000E+00</Y_TRANS>
+      <PISTON units="meters">0.0000000000000000E+00</PISTON>
+      <X_TILT units="radians">-2.1125280857086181E-07</X_TILT>
+      <Y_TILT units="radians">-3.5030140876770018E-06</Y_TILT>
+      <CLOCK units="radians">0.0000000000000000E+00</CLOCK>
+    </UPDATE>
+  </GROUP>
+
+  <GROUP id="5">
+    <UPDATE absolute="false" coord="local" id="1" seg_id="C5-16" stage_type="fine_only" type="pose">
+      <X_TRANS units="meters">0.0000000000000000E+00</X_TRANS>
+      <Y_TRANS units="meters">0.0000000000000000E+00</Y_TRANS>
+      <PISTON units="meters">0.0000000000000000E+00</PISTON>
+      <X_TILT units="radians">-9.1714277863502506E-08</X_TILT>
+      <Y_TILT units="radians">-3.5924429893493652E-06</Y_TILT>
+      <CLOCK units="radians">0.0000000000000000E+00</CLOCK>
+    </UPDATE>
+  </GROUP>
+
+  <GROUP id="6">
+    <UPDATE absolute="false" coord="local" id="1" seg_id="C6-18" stage_type="fine_only" type="pose">
+      <X_TRANS units="meters">0.0000000000000000E+00</X_TRANS>
+      <Y_TRANS units="meters">0.0000000000000000E+00</Y_TRANS>
+      <PISTON units="meters">0.0000000000000000E+00</PISTON>
+      <X_TILT units="radians">-1.4061936736106874E-07</X_TILT>
+      <Y_TILT units="radians">-3.5754411220550537E-06</Y_TILT>
+      <CLOCK units="radians">0.0000000000000000E+00</CLOCK>
+    </UPDATE>
+  </GROUP>
+
+</SEGMENT_UPDATE_REQUEST>

--- a/webbpsf/tests/test_nircam.py
+++ b/webbpsf/tests/test_nircam.py
@@ -319,3 +319,41 @@ def test_defocus(fov_arcsec=1, display=False):
         webbpsf.display_psf(psf)
         plt.figure()
         webbpsf.display_psf(psf_2)
+
+
+def test_ways_to_specify_weak_lenses():
+    """ There are multiple ways to specify combinations of weak lenses. Test they work as expected.
+
+    """
+
+
+    testcases = (
+        # FILTER  PUPIL   EXPECTED_DEFOCUS
+        # Test methods directly specifying a single element
+        ('F212N', 'WLM8', 'Weak Lens -8'),
+        ('F200W', 'WLP8', 'Weak Lens +8'),
+        ('F187N', 'WLP8', 'Weak Lens +8'),
+        # Note WLP4 can be specified as filter or pupil element or both
+        ('WLP4', 'WLP4', 'Weak Lens +4'),
+        (None, 'WLP4', 'Weak Lens +4'),
+        ('WLP4', None, 'Weak Lens +4'),
+        # Test methods directly specifying a pair of elements stacked together
+        ('WLP4', 'WLM8', 'Weak Lens Pair -4'),
+        ('WLP4', 'WLP8', 'Weak Lens Pair +12'),
+        # Test methods using virtual pupil elements WLM4 and WLP12
+        ('WLP4', 'WLM4', 'Weak Lens Pair -4'),
+        ('WLP4', 'WLP12', 'Weak Lens Pair +12'),
+        ('F212N', 'WLM4', 'Weak Lens Pair -4'),
+        ('F212N', 'WLP12', 'Weak Lens Pair +12'),
+    )
+
+    nrc = webbpsf_core.NIRCam()
+    nrc.pupilopd = None # irrelevant for this test and slows it down
+    nrc.include_si_wfe = False # irrelevant for this test and slows it down
+    for filt, pup, expected in testcases:
+        nrc.pupil_mask = pup
+        if filt is not None: nrc.filter = filt
+
+        assert expected in [p.name for p in nrc.get_optical_system().planes], "Optical system did not contain expected plane {} for {}, {}".format(expected, filt, pup)
+
+

--- a/webbpsf/tests/test_nircam.py
+++ b/webbpsf/tests/test_nircam.py
@@ -20,7 +20,7 @@ test_nircam = lambda : generic_output_test('NIRCam')
 test_nircam_source_offset_00 = lambda : do_test_source_offset('NIRCam', theta=0.0, monochromatic=2e-6)
 test_nircam_source_offset_45 = lambda : do_test_source_offset('NIRCam', theta=45.0, monochromatic=2e-6)
 
-test_nircam_set_siaf = lambda : do_test_set_position_from_siaf('NIRCam', 
+test_nircam_set_siaf = lambda : do_test_set_position_from_siaf('NIRCam',
         ['NRCA5_SUB160', 'NRCA3_DHSPIL_SUB96','NRCA5_MASKLWB_F300M', 'NRCA2_TAMASK210R'])
 
 test_nircam_blc_circ_45 =  lambda : do_test_nircam_blc(kind='circular', angle=45)
@@ -354,6 +354,6 @@ def test_ways_to_specify_weak_lenses():
         nrc.pupil_mask = pup
         if filt is not None: nrc.filter = filt
 
-        assert expected in [p.name for p in nrc.get_optical_system().planes], "Optical system did not contain expected plane {} for {}, {}".format(expected, filt, pup)
+        assert expected in [p.name for p in nrc._get_optical_system().planes], "Optical system did not contain expected plane {} for {}, {}".format(expected, filt, pup)
 
 


### PR DESCRIPTION
Two unrelated changes made in support of use of WebbPSF with MIRAGE:

- Allow WLP4 to be used as a filter, in which case also (correctly) infer the presence of the defocus as a pupil element. The combinations like +12 can now be specified _either_ with the "virtual" pupil element WLP12, or correctly with `filter=WLP4, pupil_mask=WLP8`. 

 - Improve the `ote.move_sur` function: better verbose text including display of group numbers, add an ability to run SURs in reverse (for testing or for certain mock data generation tasks), and add a unit test. 
