### PR TITLE
Correct detector_position documentation

### DIFF
--- a/docs/jwst.rst
+++ b/docs/jwst.rst
@@ -33,7 +33,7 @@ All classes share some common attributes:
    ``detector_position`` attribute which is a 2-tuple giving the pixel coordinates
    on that detector for the center location in any calculated output PSF.
    Note that the ``detector_position`` value should be
-   specified using the Python (Y,X) axes order convention.
+   specified using the order (X,Y).
 
 .. warning::
 


### PR DESCRIPTION
I received a question from Kevin Volk which lead us to find that there was an error in the WebbPSF ReadTheDocs. On the page https://webbpsf.readthedocs.io/en/stable/jwst.html in the 4th bullet point, it says that the attribute `detector_position` should be set as `(Y,X)` when on lines 322 and 323 of `webbpsf_core.py` it shows that it expects the order `(X,Y)`. So I updated the jwst.rst file to reflect what's in the code.