### PR TITLE
add pointing jitter to WFIRST sims

### DIFF
--- a/webbpsf/gridded_library.py
+++ b/webbpsf/gridded_library.py
@@ -343,9 +343,8 @@ class CreatePSFLibrary:
             meta["NORMALIZ"] = (psf[ext].header["NORMALIZ"], "PSF normalization method")
             meta["TEL_WFE"] = (psf[ext].header["TEL_WFE"], "[nm] Telescope pupil RMS wavefront error")
 
-            if self.webb.name != "WFI":
-                meta["JITRTYPE"] = (psf[ext].header["JITRTYPE"], "Type of jitter applied")
-                meta["JITRSIGM"] = (psf[ext].header["JITRSIGM"], "Gaussian sigma for jitter [arcsec]")
+            meta["JITRTYPE"] = (psf[ext].header["JITRTYPE"], "Type of jitter applied")
+            meta["JITRSIGM"] = (psf[ext].header["JITRSIGM"], "Gaussian sigma for jitter [arcsec]")
 
             meta["DATE"] = (psf[ext].header["DATE"], "Date of calculation")
             meta["AUTHOR"] = (psf[ext].header["AUTHOR"], "username@host for calculation")

--- a/webbpsf/wfirst.py
+++ b/webbpsf/wfirst.py
@@ -237,6 +237,8 @@ class WFIRSTInstrument(webbpsf_core.SpaceTelescopeInstrument):
 
     def __init__(self, *args, **kwargs):
         super(WFIRSTInstrument, self).__init__(*args, **kwargs)
+        self.options['jitter'] = 'gaussian'
+        self.options['jitter_sigma'] = 0.014   # See https://wfirst.ipac.caltech.edu/sims/Param_db.html#telescope
 
     # slightly different versions of the following two functions
     # from the parent superclass


### PR DESCRIPTION
During review of #294, I realized that the WFI sims didn't include the pointing jitter model, unlike the case for JWST. This is very simple to add in, so I did so. 

The predicted WFI pointing stability appears to be 14 milliarcseconds per axis. See https://wfirst.ipac.caltech.edu/sims/Param_db.html#telescope. I've asked Ed Nelan to double check that this is the latest predicted value consistent with cycle 8. 