### PR TITLE
Fix docs missing links

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -57,7 +57,7 @@ WebbPSF and its underlying optical library POPPY may be installed from the `Pyth
 
     Successfully installed webbpsf
 
-Note that ``pip install webbpsf`` only installs the program code. **If you install via pip, you must manually download and install the data files, as :ref:`described <data_install>` below.**
+Note that ``pip install webbpsf`` only installs the program code. **If you install via pip, you must manually download and install the data files, as** :ref:`described <data_install>` **below.**
 To obtain source spectra for calculations, you should also follow :ref:`installation instructions for pysynphot <pysynphot_install>`.
 
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -66,7 +66,7 @@ To obtain source spectra for calculations, you should also follow :ref:`installa
 Installing or updating pysynphot
 --------------------------------
 
-Pysynphot is an optional dependency, but is highly recommended.  Pysynphot is best installed via AstroConda. Further installation instructions can be found in `the pysynphot docs <https://pysynphot.readthedocs.io/en/latest/#installation-and-setup>` or `a discussion in the POPPY docs <http://poppy-optics.readthedocs.io/en/stable/installation.html#installing-or-updating-pysynphot>`_.
+Pysynphot is an optional dependency, but is highly recommended.  Pysynphot is best installed via AstroConda. Further installation instructions can be found in `the pysynphot docs <https://pysynphot.readthedocs.io/en/latest/#installation-and-setup>`_ or `a discussion in the POPPY docs <http://poppy-optics.readthedocs.io/en/stable/installation.html#installing-or-updating-pysynphot>`_.
 
 .. _data_install:
 


### PR DESCRIPTION
Found 2 cases of broken/missing links in the docs installation section

Fixes issue #329 