### PR TITLE
improve reproducibility of thermal slew SM model. Fixes #338

### DIFF
--- a/webbpsf/tests/test_opds.py
+++ b/webbpsf/tests/test_opds.py
@@ -104,6 +104,28 @@ def test_thermal_slew_update_opd():
     max_truth = 4.13338e-08 / 1e-9 # Convert the max truth to units of nm
     assert np.isclose(np.max(otelm.opd)/1e-9, max_truth), "OPD max does not match expected value after 1 day slew."
 
+
+def test_thermal_slew_reproducibility():
+    """ If you call the thermal slew model multiple times, the OPD values should depend
+    only on the LAST set of function call parameters. Not on the full time history.
+
+    See issue #338
+    """
+    ote = webbpsf.opds.OTE_Linear_Model_WSS()
+
+    ote.thermal_slew(12*u.hour, start_angle=-5, end_angle=45)
+    opd1 = ote.opd.copy()
+
+    ote.thermal_slew(24*u.hour, start_angle=-5, end_angle=45)
+    opd2 = ote.opd.copy()
+
+    ote.thermal_slew(12*u.hour, start_angle=-5, end_angle=45)
+    opd3 = ote.opd.copy()
+
+    assert np.allclose(opd1, opd2)==False, "OPDs expected to differ didn't"
+    assert np.allclose(opd1, opd3), "OPDs expected to match didn't"
+
+
 def test_update_opd():
     ''' The start of what should be many tests of this function'''
     otelm = webbpsf.opds.OTE_Linear_Model_WSS()


### PR DESCRIPTION
Several small changes to the OTE linear model to fix spacetelescope/webbpsf#338 
 - Clarify in doc string of `thermal_slew` that multiple calls in a row to this function aren't cumulative, but rather it resets back to the starting point OPD each time. 
 - Fix a small bug in the `update_opd` function, which prevented the above from being completely true. See note in spacetelescope/webbpsf#338, about how the SM defocus would get repeatedly added into the global hexikes array. This resulted in different results if you called the function multiple times in a row with the same parameters. 
 - Re-enable the global zernikes option as well as the global hexikes option (so that the `move_global_zernikes` function will actually work)
 - Add unit test for the fix of the SM defocus bug. 