### PR TITLE
Add options for image blurring in Coarse Point mode

### DIFF
--- a/webbpsf/tests/test_jitter.py
+++ b/webbpsf/tests/test_jitter.py
@@ -1,0 +1,22 @@
+import webbpsf
+
+
+def test_coarse_jitter():
+    """ Test the jitter options for Coarse Point mode
+    Simple test to verify functionality, and sanity check that more
+    blur means a less sharp PSF.
+    """
+    nrc = webbpsf.NIRCam()
+    nrc.include_si_wfe = False
+    nrc.options['jitter']='PCS=Coarse'
+    psf_coarse = nrc.calc_psf(nlambda=1, add_distortion=False, fov_pixels=30)
+
+    nrc.options['jitter']='PCS=Coarse_Like_ITM'
+    psf_coarse_like_itm = nrc.calc_psf(nlambda=1, add_distortion=False, fov_pixels=30)
+
+    # These test values are handwaved without any particular rigor
+    assert psf_coarse[0].header['JITRSTRL'] < 0.25, "Coarse point blurs the image less than expected"
+
+    assert psf_coarse_like_itm[0].header['JITRSTRL'] < 0.05, "Coarse point (Like ITM) blurs the image less than expected"
+
+


### PR DESCRIPTION
Add model for image jitter with JWST in coarse point mode, under two different assumptions about LOS stability. 

Example:

```python
psf = nrc.calc_psf(nlambda=1, add_distortion=False)

nrc.options['jitter']='PCS=Coarse'
psf_coarse = nrc.calc_psf(nlambda=1, add_distortion=False)

nrc.options['jitter']='PCS=Coarse_Like_ITM'
psf_coarse_like_itm = nrc.calc_psf(nlambda=1, add_distortion=False)

fig, axes = plt.subplots(figsize=(15,5), ncols=3)

for ax, eachpsf, title in zip(axes, [psf, psf_coarse, psf_coarse_like_itm],
                             ['Gaussian, $\sigma$=7 mas', 'Gaussian, $\sigma$=67 mas', 'Like ITM']):

    webbpsf.display_psf(eachpsf, ext=1, ax=ax, colorbar=False, title=title)
```

![Unknown-4](https://user-images.githubusercontent.com/1151745/76009991-21bde600-5ee0-11ea-9ee0-84e1e1a9f084.png)