### PR TITLE
NIRCam Coronagraph PSF Dispersion

### DIFF
--- a/webbpsf/tests/test_nircam.py
+++ b/webbpsf/tests/test_nircam.py
@@ -421,4 +421,4 @@ def test_nircam_coron_wfe_offset(fov_pix=15, oversample=2, fit_gaussian=True):
     assert np.allclose( diff_25_33, 0.016, rtol=rtol), "PSF shift between {:.2f} and {:.2f} um of {:.3f} mm does not match expected value (~0.016 mm).".format(warr[1], warr[0], diff_25_33)
     # Difference from 3.3 to 5.0 um should be ~0.030mm
     diff_50_33 = np.abs(yloc[2] - yloc[1])
-    assert np.allclose( diff_50_33, 0.032, rtol=rtol), "PSF shift between {:.2f} and {:.2f} um of {:.3f} mm does not match expected value (~0.032 mm).".format(warr[1], warr[0], diff_25_33)
+    assert np.allclose( diff_50_33, 0.032, rtol=rtol), "PSF shift between {:.2f} and {:.2f} um of {:.3f} mm does not match expected value (~0.032 mm).".format(warr[1], warr[2], diff_50_33)

--- a/webbpsf/tests/test_nircam.py
+++ b/webbpsf/tests/test_nircam.py
@@ -395,7 +395,7 @@ def test_nircam_coron_wfe_offset(fov_pix=15, oversample=2):
         fit_g = fitting.LevMarLSQFitter()
         g = fit_g(g_init, xvals, yvals)
         yloc.append(g.mean.value)
-    yloc = np.array(yloc_on)
+    yloc = np.array(yloc)
 
     # Difference values should be greater than 0.010mm
     # Should be along the lines of 0.013mm between wave=3.23 and 2.5um, 

--- a/webbpsf/tests/test_nircam.py
+++ b/webbpsf/tests/test_nircam.py
@@ -366,7 +366,7 @@ def test_nircam_coron_wfe_offset(fov_pix=15, oversample=2, fit_gaussian=True):
     """
 
     # Disable Gaussian fit if astropy not installed
-    if fit_guassian:
+    if fit_gaussian:
         try:
             from astropy.modeling import models, fitting
         except ImportError:
@@ -375,6 +375,9 @@ def test_nircam_coron_wfe_offset(fov_pix=15, oversample=2, fit_gaussian=True):
     # Ensure oversample to >1 no Gaussian fitting
     if fit_gaussian == False:
         oversample = 2 if oversample<2 else oversample
+        rtol = 0.2
+    else:
+        rtol = 0.1
 
     # Set up an off-axis coronagraphic PSF
     inst = webbpsf_core.NIRCam()
@@ -415,9 +418,7 @@ def test_nircam_coron_wfe_offset(fov_pix=15, oversample=2, fit_gaussian=True):
 
     # Difference from 2.5 to 3.3 um should be ~0.015mm
     diff_25_33 = np.abs(yloc[0] - yloc[1])
-    assert diff_25_33 > 0.01, "Expected PSF shift between {:.2f} and {:.2f} um is too small ({:.3f} mm).".format(warr[1], warr[0], diff_25_33)
-    assert diff_25_33 < 0.02, "Expected PSF shift between {:.2f} and {:.2f} um is too large ({:.3f} mm).".format(warr[1], warr[0], diff_25_33)
+    assert np.allclose( diff_25_33, 0.016, rtol=rtol), "PSF shift between {:.2f} and {:.2f} um of {:.3f} mm does not match expected value (~0.016 mm).".format(warr[1], warr[0], diff_25_33)
     # Difference from 3.3 to 5.0 um should be ~0.030mm
     diff_50_33 = np.abs(yloc[2] - yloc[1])
-    assert diff_50_33 > 0.02, "Expected PSF shift between {:.2f} and {:.2f} um is too small ({:.3f} mm).".format(warr[1], warr[2], diff_50_33)
-    assert diff_50_33 < 0.04, "Expected PSF shift between {:.2f} and {:.2f} um is too large ({:.3f} mm).".format(warr[1], warr[2], diff_50_33)
+    assert np.allclose( diff_50_33, 0.032, rtol=rtol), "PSF shift between {:.2f} and {:.2f} um of {:.3f} mm does not match expected value (~0.032 mm).".format(warr[1], warr[0], diff_25_33)


### PR DESCRIPTION
Apply wavelength dependent offsets for NIRCam coronagraphic PSFs. This is due to the dispersion from the optical wedge in the coronagraphic pupil masks. Primarily affects the LW channel (approximately 0.015 mm/um dispersion). SW channel is almost a factor of 10 smaller (fairly negligible), but we include it for completeness. The PSF shift is implemented by modifying the tilt Zernike coefficient (Z3) within the NIRCamFieldAndWavelengthDependentAberration function. Values have been determined using the Zernike offsets as reported in the NIRCam Zemax models. Center reference positions correspond to the NIRCam target acquisition filters (3.35um for LW and 2.1um for SW). Implementation is similar to the NIRCam Zernike and focus updates from #283.

Additional minor changes to `optics.py`:
- Ensure `wave` is a `poppy.Wavefront` object and `wavelength` is generally an `astropy.unit `quantity.
- Create a convenience variable `is_nrc_coron` rather than awkwardly checking NIRCam pupil string values multiple times
- Zernike values stored in FITS header are in units of [m], not [nm]
- Added a unit test to check wavelength dependent PSF offset

This pull request replaces PR #335 in the master branch.