### PR TITLE
Travis test max version to py38

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,6 @@ matrix:
         - env: TOXENV='py37-astropydev-test'
 
         # Try minimum supported versions
-        - env: TOXENV='py35-legacy35-test'
         - env: TOXENV='py36-legacy36-test'
 
         # Try released POPPY

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,13 +19,13 @@ matrix:
         # do the actual tests against dev version of POPPY
 
         # Do a coverage test in Python 3.
-        - env: TOXENV='py37-poppydev-pysiafdev-cov'
+        - env: TOXENV='py38-poppydev-pysiafdev-cov'
 
         # Check for Sphinx doc build errors
         - env: TOXENV='docbuild' TOX_ARGS=''
 
         # Try Astropy development version
-        - env: TOXENV='py37-astropydev-test'
+        - env: TOXENV='py38-astropydev-test'
 
         # Try minimum supported versions
         - env: TOXENV='py36-legacy36-test'

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -105,7 +105,7 @@ Software Requirements
 
 See `the environment.yml specification file <https://github.com/spacetelescope/webbpsf/blob/master/environment.yml>`_ for the required package dependencies. 
 
-**Required Python version**: WebbPSF 0.8 and above require Python 3.5 or higher.
+**Required Python version**: WebbPSF 0.9.1 and above require Python 3.6 or higher.
 
 The major dependencies are the standard `NumPy, SciPy <http://www.scipy.org/scipylib/download.html>`_, `matplotlib <http://matplotlib.org>`_ stack, and `Astropy <http://astropy.org>`_
 

--- a/docs/relnotes.rst
+++ b/docs/relnotes.rst
@@ -37,6 +37,10 @@ Version 0.9.1
 
  - Future changes here
 
+**Software and Package Infrastructure Updates:**
+ 
+ - The minimum Python version is now 3.6. 
+
 Version 0.9.0
 =============
 *2019 November 25*

--- a/environment.yml
+++ b/environment.yml
@@ -2,7 +2,7 @@ channels:
   - http://ssb.stsci.edu/astroconda
   - defaults
 dependencies:
-  - python>=3.5
+  - python>=3.6
   - ipython>=6.0.0
   - numpy>=1.13.0
   - scipy>=1.0.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ install_requires =
     poppy>=0.9.0
     jwxml>=0.3.0
     pysiaf>=0.6.0
-python_requires = >=3.5
+python_requires = >=3.6
 setup_requires = setuptools_scm
 
 [options.extras_require]

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,9 @@
 [tox]
 envlist =
-    py{36,37}-test
-    py{36,37}-{poppydev,pysiafdev,astropydev,stable}-test
+    py{36,37,38}-test
+    py{36,37,38}-{poppydev,pysiafdev,astropydev,stable}-test
     py36-legacy36-test
-    py{36,37}-{poppydev,pysiafdev}-cov
+    py{36,37,38}-{poppydev,pysiafdev}-cov
 
 [testenv]
 passenv = *
@@ -31,7 +31,7 @@ commands=
     cov: codecov -F -e TOXENV
 
 [testenv:docbuild]
-basepython= python3.7
+basepython= python3.8
 passenv= *
 deps=
     sphinx
@@ -49,7 +49,7 @@ commands=
     sphinx-build docs docs/_build
 
 [testenv:codestyle]
-basepython= python3.7
+basepython= python3.8
 skip_install = true
 description = check package code style
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -1,19 +1,17 @@
 [tox]
 envlist =
-    py{35,36,37}-test
-    py{35,36,37}-{poppydev,pysiafdev,astropydev,stable}-test
-    py35-legacy35-test
+    py{36,37}-test
+    py{36,37}-{poppydev,pysiafdev,astropydev,stable}-test
     py36-legacy36-test
-    py{35,36,37}-{poppydev,pysiafdev}-cov
+    py{36,37}-{poppydev,pysiafdev}-cov
 
 [testenv]
 passenv = *
 deps =
     pytest
     jwxml
-    poppydev,legacy35,legacy36,astropydev: git+https://github.com/spacetelescope/poppy.git#egg=poppy
-    pysiafdev,legacy35,legacy36,astropydev: git+https://github.com/spacetelescope/pysiaf.git#egg=pysiaf
-    legacy35: numpy==1.13.*
+    poppydev,legacy36,astropydev: git+https://github.com/spacetelescope/poppy.git#egg=poppy
+    pysiafdev,legacy36,astropydev: git+https://github.com/spacetelescope/pysiaf.git#egg=pysiaf
     legacy36: numpy==1.16.*
     astropydev: git+git://github.com/astropy/astropy
     stable: poppy

--- a/webbpsf/__init__.py
+++ b/webbpsf/__init__.py
@@ -25,7 +25,7 @@ except ImportError:
 
 __all__ = ['__version__']
 
-__minimum_python_version__ = "3.5"
+__minimum_python_version__ = "3.6"
 
 
 class UnsupportedPythonError(Exception):


### PR DESCRIPTION
Python 3.8 has been out since October, so we should start running that as part of the test suites for the dev versions. 