### PR TITLE
Update pysiaf version requirement

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -11,4 +11,4 @@ dependencies:
   - photutils>=0.6
   - poppy>=0.9.0
   - jwxml>=0.3.0
-  - pysiaf>=0.6.0
+  - pysiaf>=0.9.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,7 @@ install_requires =
     photutils>=0.6.0
     poppy>=0.9.0
     jwxml>=0.3.0
-    pysiaf>=0.6.0
+    pysiaf>=0.9.0
 python_requires = >=3.6
 setup_requires = setuptools_scm
 


### PR DESCRIPTION
Updating `pysiaf` version in `setup.cfg` and `environment.yaml` files. 

Right now `pysiaf` v0.9.0 has been released on `pip` but it waiting to be released on `astroconda` (https://github.com/astroconda/astroconda-contrib/pull/653). We may want to wait until it's officially released to merge this PR so as not to break anything - TBD