### PR TITLE
Generalize aperturename across all SIs

### DIFF
--- a/docs/jwst.rst
+++ b/docs/jwst.rst
@@ -34,6 +34,11 @@ All classes share some common attributes:
    on that detector for the center location in any calculated output PSF.
    Note that the ``detector_position`` value should be
    specified using the order (X,Y).
+ * The ``aperturename`` attribute provides the `SIAF <https://pysiaf.readthedocs.io>`_ aperture name 
+   used for transforming between detector position and instrument field of view on the sky. By default
+   this will be a full-frame aperture for the currently-selected detector, but you may select any
+   subarray aperture or other aperture named in the SIAF for that instrument. For NIRCam and MIRI,
+   the aperturename can (optionally) automatically update for coronagraphic subarrays.
 
 .. warning::
 
@@ -114,7 +119,6 @@ just set the desired detector and the channel and module are inferred
 automatically.
 
 
-
 The choice of ``filter`` also impacts the channel selection: If you choose a
 long-wavelength filter such as F460M, then the detector will automatically
 switch to the long-wave detector for the current channel. For example, if the
@@ -144,6 +148,7 @@ behavior on filter selection can be disabled by setting ``nircam.auto_channel = 
     filter or detector attribute whenever you want to toggle between SW or LW channels.
 
 
+
 Coronagraph Masks
 ------------------
 
@@ -161,6 +166,13 @@ Note, the Lyot masks have multiple names for historical reasons: The names
 can still be used, but the same masks can also be referred to as "MASKRND" and
 "MASKSWB" or "MASKLWB", the nomenclature that was eventually adopted for use in
 APT and other JWST documentation. Both ways work and will continue to do so.
+
+The NIRCam class can automatically switch its ``aperturename`` attribute when a
+coronagraphic mask is selected, to select the aperturename for the appropriate
+coronagraphic subarray.  The detector reference pixel location will also update
+to the center of the coronagraphic subarray. This behavior on image mask or
+pupil mask selection can be disabled by setting ``nircam.auto_aperturename =
+False``.
 
 **Offsets along the MASKLWB and MASKSWB masks**:
 
@@ -360,6 +372,11 @@ co-mounted. WebbPSF models this by automatically setting the ``pupil_mask``
 element to one of the coronagraph masks or the regular pupil when the ``filter``
 is changed. If you want to disable this behavior, set ``miri.auto_pupil = False``.
 
+The MIRI class can automatically switch its ``aperturename`` attribute when a
+coronagraphic mask is selected, to select the aperturename for the appropriate
+coronagraphic subarray.  The detector reference pixel location will also update
+to the center of the coronagraphic subarray. This behavior on image mask
+selection can be disabled by setting ``miri.auto_aperturename = False``.
 
 LRS Spectroscopy
 ----------------

--- a/docs/jwst.rst
+++ b/docs/jwst.rst
@@ -34,11 +34,13 @@ All classes share some common attributes:
    on that detector for the center location in any calculated output PSF.
    Note that the ``detector_position`` value should be
    specified using the order (X,Y).
- * The ``aperturename`` attribute provides the `SIAF <https://pysiaf.readthedocs.io>`_ aperture name 
+ * The ``aperturename`` attribute provides the `SIAF <https://pysiaf.readthedocs.io>`_ aperture name
    used for transforming between detector position and instrument field of view on the sky. By default
    this will be a full-frame aperture for the currently-selected detector, but you may select any
-   subarray aperture or other aperture named in the SIAF for that instrument. For NIRCam and MIRI,
-   the aperturename can (optionally) automatically update for coronagraphic subarrays.
+   subarray aperture or other aperture named in the SIAF for that instrument. The aperturename will always
+   update automatically when you select a new detector name. For NIRCam and MIRI,
+   the aperturename can also (optionally) automatically update for coronagraphic subarrays if/when a coronagraphic
+   optic is selected for the image or pupil mask. .
 
 .. warning::
 

--- a/webbpsf/tests/test_miri.py
+++ b/webbpsf/tests/test_miri.py
@@ -1,39 +1,39 @@
-import sys, os
-import numpy as np
-import matplotlib.pyplot as plt
-import astropy.io.fits as fits
-
 import logging
+import os
+
+import numpy as np
+
 _log = logging.getLogger('test_webbpsf')
 _log.addHandler(logging.NullHandler())
 
 from .. import webbpsf_core
-import poppy
 
-
-#------------------    MIRI Tests    ----------------------------
+# ------------------    MIRI Tests    ----------------------------
 
 from .test_webbpsf import generic_output_test, do_test_source_offset, do_test_set_position_from_siaf
 
-test_miri= lambda : generic_output_test('MIRI')
-test_miri_source_offset_00 = lambda : do_test_source_offset('MIRI', theta=0.0, monochromatic=8e-6)
-test_miri_source_offset_45 = lambda : do_test_source_offset('MIRI', theta=45.0, monochromatic=8e-6)
+test_miri = lambda: generic_output_test('MIRI')
+test_miri_source_offset_00 = lambda: do_test_source_offset('MIRI', theta=0.0, monochromatic=8e-6)
+test_miri_source_offset_45 = lambda: do_test_source_offset('MIRI', theta=45.0, monochromatic=8e-6)
 
-test_miri_set_siaf = lambda : do_test_set_position_from_siaf('MIRI',
-        ['MIRIM_SUB128','MIRIM_FP1MIMF','MIRIM_BRIGHTSKY', 'MIRIM_TASLITLESSPRISM',])
+test_miri_set_siaf = lambda: do_test_set_position_from_siaf('MIRI',
+                                                            ['MIRIM_SUB128', 'MIRIM_FP1MIMF', 'MIRIM_BRIGHTSKY',
+                                                             'MIRIM_TASLITLESSPRISM', ])
 
-def do_test_miri_fqpm(nlambda=1, clobber=True, angle=0.0, offset=0.0, oversample=2, outputdir=None, display=False, save=False):
+
+def do_test_miri_fqpm(nlambda=1, clobber=True, angle=0.0, offset=0.0, oversample=2, outputdir=None, display=False,
+                      save=False):
     miri = webbpsf_core.MIRI()
     miri.pupilopd = None
-    miri.filter='F1065C'
+    miri.filter = 'F1065C'
     miri.image_mask = 'FQPM1065'
     miri.pupil_mask = 'MASKFQPM'
 
-    #for offset in np.linspace(0.0, 1.0, nsteps):
-    #miri.options['source_offset_theta'] = 0.0
+    # for offset in np.linspace(0.0, 1.0, nsteps):
+    # miri.options['source_offset_theta'] = 0.0
     miri.options['source_offset_r'] = offset
 
-    #for angle in [0,45]:
+    # for angle in [0,45]:
     miri.options['source_offset_theta'] = angle
     psf = miri.calc_psf(oversample=oversample, nlambda=nlambda, save_intermediates=False, display=display)
 
@@ -42,11 +42,11 @@ def do_test_miri_fqpm(nlambda=1, clobber=True, angle=0.0, offset=0.0, oversample
             import tempfile
             outputdir = tempfile.gettempdir()
 
-
-        fn = os.path.join(outputdir, 'test_miri_fqpm_t{0}_r{1:.2f}.fits'.format(angle,offset))
+        fn = os.path.join(outputdir, 'test_miri_fqpm_t{0}_r{1:.2f}.fits'.format(angle, offset))
         psf.writeto(fn, clobber=clobber)
 
-    #FIXME - add some assertion tests here.
+    # FIXME - add some assertion tests here.
+
 
 def test_miri_fqpm_centered(*args, **kwargs):
     do_test_miri_fqpm(angle=0.0, offset=0.0)

--- a/webbpsf/tests/test_miri.py
+++ b/webbpsf/tests/test_miri.py
@@ -67,8 +67,7 @@ def test_miri_aperturename():
 
     ref_tel_coords = miri._tel_coords()
 
-    miri.aperturename = 'MIRIM_SUB128'
-    assert miri.detector_position == (
-        64, 64), "Changing to a subarray aperture didn't change the reference pixel coords as expected"
-    assert not np.all(
-        miri._tel_coords() != ref_tel_coords), "Changing to a subarray aperture didn't change the V2V3 coords as expected."
+    miri.aperturename = 'MIRIM_SUB256'
+    assert miri.detector_position == (128, 128), "Changing to a subarray aperture didn't change the " \
+                                                 "reference pixel coords as expected"
+    assert np.any( miri._tel_coords() != ref_tel_coords), "Changing to a subarray aperture didn't change the V2V3 coords as expected."

--- a/webbpsf/tests/test_miri.py
+++ b/webbpsf/tests/test_miri.py
@@ -55,7 +55,20 @@ def test_miri_fqpm_centered(*args, **kwargs):
 def test_miri_fqpm_offset_00(*args, **kwargs):
     do_test_miri_fqpm(angle=0.0, offset=1.0)
 
+
 def test_miri_fqpm_offset_45(*args, **kwargs):
     do_test_miri_fqpm(angle=45.0, offset=1.0)
 
 
+def test_miri_aperturename():
+    """ Test aperture name functionality """
+    miri = webbpsf_core.MIRI()
+    assert miri.aperturename == miri._detectors[miri.detector], "Default SIAF aperture is not as expected"
+
+    ref_tel_coords = miri._tel_coords()
+
+    miri.aperturename = 'MIRIM_SUB128'
+    assert miri.detector_position == (
+        64, 64), "Changing to a subarray aperture didn't change the reference pixel coords as expected"
+    assert not np.all(
+        miri._tel_coords() != ref_tel_coords), "Changing to a subarray aperture didn't change the V2V3 coords as expected."

--- a/webbpsf/tests/test_niriss.py
+++ b/webbpsf/tests/test_niriss.py
@@ -55,3 +55,18 @@ def test_niriss_gr700xd():
     niriss.filter = 'CLEAR'
     niriss.pupil_mask = 'GR700XD'
     niriss.calc_psf(monochromatic=1e-6, fov_pixels=2)
+
+
+def test_niriss_aperturename():
+    """ Not a lot of options here """
+    niriss = webbpsf_core.NIRISS()
+    assert niriss.aperturename == niriss._detectors[niriss.detector], "Default SIAF aperture is not as expected"
+
+    ref_tel_coords = niriss._tel_coords()
+
+    niriss.aperturename = 'NIS_SUB128'
+    assert niriss.detector_position == (64, 64), "Changing to a subarray aperture didn't change the " \
+                                                 "reference pixel coords as expected"
+    assert np.any(
+        niriss._tel_coords() != ref_tel_coords), "Changing to a subarray aperture didn't change the V2V3 coords " \
+                                                 "as expected."

--- a/webbpsf/tests/test_niriss.py
+++ b/webbpsf/tests/test_niriss.py
@@ -1,24 +1,24 @@
-import sys, os
-import numpy as np
-import matplotlib.pyplot as plt
-import astropy.io.fits as fits
-
 import logging
-_log = logging.getLogger('test_webbpsf')
-_log.addHandler(logging.NullHandler())
+
+import numpy as np
+
+#_log = logging.getLogger('test_webbpsf')
+#_log.addHandler(logging.NullHandler())
 
 from .. import webbpsf_core
-import poppy
 
-#------------------    NIRISS Tests    ----------------------------
+# ------------------    NIRISS Tests    ----------------------------
 
 from .test_webbpsf import generic_output_test, do_test_source_offset, do_test_set_position_from_siaf
-test_niriss= lambda : generic_output_test('NIRISS')
-test_niriss_source_offset_00 = lambda : do_test_source_offset('NIRISS', theta=0.0, monochromatic=3.0e-6)
-test_niriss_source_offset_45 = lambda : do_test_source_offset('NIRISS', theta=45.0, monochromatic=3.0e-6)
 
-test_niriss_set_siaf = lambda : do_test_set_position_from_siaf('NIRISS', 
-        ['NIS_FP1MIMF', 'NIS_SUB64', 'NIS_SOSSFULL','NIS_SOSSTA','NIS_AMI1'])
+test_niriss = lambda: generic_output_test('NIRISS')
+test_niriss_source_offset_00 = lambda: do_test_source_offset('NIRISS', theta=0.0, monochromatic=3.0e-6)
+test_niriss_source_offset_45 = lambda: do_test_source_offset('NIRISS', theta=45.0, monochromatic=3.0e-6)
+
+test_niriss_set_siaf = lambda: do_test_set_position_from_siaf('NIRISS',
+                                                              ['NIS_FP1MIMF', 'NIS_SUB64', 'NIS_SOSSFULL', 'NIS_SOSSTA',
+                                                               'NIS_AMI1'])
+
 
 def test_niriss_auto_pupil():
     """ Test switching between CLEAR and CLEARP
@@ -28,28 +28,29 @@ def test_niriss_auto_pupil():
     niriss = webbpsf_core.NIRISS()
     assert niriss.pupil_mask is None
 
-    niriss.filter='F277W'
+    niriss.filter = 'F277W'
     niriss.calc_psf(nlambda=1)
     assert niriss.pupil_mask == 'CLEARP'
 
-    niriss.filter='F090W'
+    niriss.filter = 'F090W'
     niriss.calc_psf(nlambda=1)
     assert niriss.pupil_mask is None
 
-    niriss.filter='F480M'
+    niriss.filter = 'F480M'
     niriss.calc_psf(nlambda=1)
     assert niriss.pupil_mask == 'CLEARP'
 
-    niriss.filter='F200W'
+    niriss.filter = 'F200W'
     niriss.calc_psf(nlambda=1)
     assert niriss.pupil_mask is None
+
 
 def test_niriss_gr700xd():
-    '''
+    """
     Smoke-test calculations with the GR700XD custom optic
     present in the system. This is a regression test for
     https://github.com/mperrin/webbpsf/issues/148
-    '''
+    """
     niriss = webbpsf_core.NIRISS()
     niriss.filter = 'CLEAR'
     niriss.pupil_mask = 'GR700XD'

--- a/webbpsf/webbpsf_core.py
+++ b/webbpsf/webbpsf_core.py
@@ -1442,7 +1442,10 @@ class MIRI(JWInstrument):
 
         # Need to send correct aperture name for coronagraphic masks
         if (self._image_mask is not None):
-            apname = self._image_mask_apertures[self._image_mask]
+            if 'LRS' in self._image_mask:
+                apname = 'MIRIM_FULL'  # LRS slit uses full array readout
+            else:
+                apname = self._image_mask_apertures[self._image_mask]
         else:
             apname = 'MIRIM_FULL'
 

--- a/webbpsf/webbpsf_core.py
+++ b/webbpsf/webbpsf_core.py
@@ -899,7 +899,7 @@ class JWInstrument(SpaceTelescopeInstrument):
                                           "[arcmin] Det. pos. in telescope V2,V3 coord sys"), after=True)
         result[0].header.insert("DET_V2", ('DET_V3', v2v3pos[1].value,
                                            "[arcmin] Det. pos. in telescope V2,V3 coord sys"), after=True)
-        hdulist[0].header["APERNAME"] = (self._aperturename, "SIAF aperture name")
+        result[0].header["APERNAME"] = (self._aperturename, "SIAF aperture name")
 
     def calc_psf(self, outfile=None, source=None, nlambda=None, monochromatic=None,
                  fov_arcsec=None, fov_pixels=None, oversample=None, detector_oversample=None, fft_oversample=None,

--- a/webbpsf/webbpsf_core.py
+++ b/webbpsf/webbpsf_core.py
@@ -899,7 +899,7 @@ class JWInstrument(SpaceTelescopeInstrument):
                                           "[arcmin] Det. pos. in telescope V2,V3 coord sys"), after=True)
         result[0].header.insert("DET_V2", ('DET_V3', v2v3pos[1].value,
                                            "[arcmin] Det. pos. in telescope V2,V3 coord sys"), after=True)
-        result[0].header["APERNAME"] = (self._detectors[self._detector], "SIAF aperture name")
+        hdulist[0].header["APERNAME"] = (self._aperturename, "SIAF aperture name")
 
     def calc_psf(self, outfile=None, source=None, nlambda=None, monochromatic=None,
                  fov_arcsec=None, fov_pixels=None, oversample=None, detector_oversample=None, fft_oversample=None,
@@ -1956,8 +1956,6 @@ class NIRCam(JWInstrument):
         hdulist[0].header['CHANNEL'] = ('Short' if self.channel == 'short' else 'Long', 'NIRCam channel: long or short')
         # filter, pupil added by calc_psf header code
         hdulist[0].header['PILIN'] = ('False', 'Pupil imaging lens in optical path: T/F')
-        # Update APERNAME
-        hdulist[0].header["APERNAME"] = (self._aperturename, "SIAF aperture name")
 
 class NIRSpec(JWInstrument):
     """ A class modeling the optics of NIRSpec, in **imaging** mode.


### PR DESCRIPTION
Refactor the `aperturename` functionality from #351 to generalize across instruments. 

- [x] Provide `inst.aperturename` attribute across all SpaceTelescopeInstrument subclasses
- [x] Implement default aperture names for all instruments as the full frame apertures (which is what we we doing before behind the scenes, but now it's explicitly visible as the attribute)
- [x] Implement `auto_aperturename` functionality for MIRI, selecting based on corona graphic masks, so roughly consistent with how it works for NIRCam.   

@JarronL would you be willing to take a look at this please? I don't seem to be able to officially tag you as a reviewer, perhaps because you're external to the spacetelescope organization on here... Let me see if I can find a work around for that...