### PR TITLE
Set origin='lower' in display_opd()

### DIFF
--- a/webbpsf/opds.py
+++ b/webbpsf/opds.py
@@ -346,7 +346,7 @@ class OPD(poppy.FITSOpticalElement):
         if ax is None:
             ax = plt.gca()
 
-        plot = ax.imshow(self.opd * mask * scalefact, vmin=-vmax, vmax=vmax, cmap=cmap, extent=extent)
+        plot = ax.imshow(self.opd * mask * scalefact, vmin=-vmax, vmax=vmax, cmap=cmap, extent=extent, origin='lower')
 
         _log.debug("Displaying OPD. Vmax is %f, data max is %f " % (vmax, self.opd.max()))
 


### PR DESCRIPTION
Following a question from Brian Hicks, I added an `origin='lower'` argument to the `display_opd` function in order to keep the labeling/struts/segments all straight. See the before and after pictures below which were created with the lines 
```
nc, ote = webbpsf.enable_adjustable_ote(nc) 
ote.move_seg_local('A1', roc=.5) 
ote.display_opd()
```


Before the change was applied:
<img width="752" alt="opd_before" src="https://user-images.githubusercontent.com/31218961/84170307-651f7780-aa2e-11ea-8ed7-5507c7554d4f.png">
After this change was applied: 
<img width="752" alt="opd_after" src="https://user-images.githubusercontent.com/31218961/84170319-68b2fe80-aa2e-11ea-92e7-0036705946a6.png">

