### PR TITLE
Include First steps of WFIRST -> Roman renaming

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,4 @@
-WebbPSF: Simulated Point Spread Functions for JWST and WFIRST
+WebbPSF: Simulated Point Spread Functions for JWST and Roman
 =============================================================
 
 .. image:: docs/readme_fig.png
@@ -22,7 +22,7 @@ flagship infrared space telescope. WebbPSF can simulate images for any of the
 four science instruments plus the fine guidance sensor, including both direct
 imaging and coronagraphic modes.
 
-WebbPSF also supports simulating PSFs for the upcoming Wide Field Infrared Survey Telescope (WFIRST),
+WebbPSF also supports simulating PSFs for the upcoming Nancy Grace Roman Telescope (formerly WFIRST),
 including its Wide Field Instrument and a preliminary version of the Coronagraph Instrument.
 
 Developed by Marshall Perrin, Joseph Long, Neil Zimmerman, Robel Geda, Shannon

--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,5 @@
-WebbPSF: Simulated Point Spread Functions for JWST and Roman
-=============================================================
+WebbPSF: Simulated Point Spread Functions for the James Webb and Nancy Grace Roman Space Telescopes
+===================================================================================================
 
 .. image:: docs/readme_fig.png
 
@@ -22,7 +22,7 @@ flagship infrared space telescope. WebbPSF can simulate images for any of the
 four science instruments plus the fine guidance sensor, including both direct
 imaging and coronagraphic modes.
 
-WebbPSF also supports simulating PSFs for the upcoming Nancy Grace Roman Telescope (formerly WFIRST),
+WebbPSF also supports simulating PSFs for the upcoming Nancy Grace Roman Space Telescope (formerly WFIRST),
 including its Wide Field Instrument and a preliminary version of the Coronagraph Instrument.
 
 Developed by Marshall Perrin, Joseph Long, Neil Zimmerman, Robel Geda, Shannon

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,7 +1,7 @@
 Documentation for WebbPSF
 ===============================
 
-WebbPSF is a Python package that computes simulated point spread functions (PSFs) for NASA's James Webb Space Telescope (JWST) and Nancy Grace Roman Telescope (formerly WFIRST). WebbPSF transforms models of telescope and instrument optical state into PSFs, taking into account detector pixel scales, rotations, filter profiles, and point source spectra. It is *not* a full optical model of JWST, but rather a tool for transforming optical path difference (OPD) maps, created with some other tool, into the resulting PSFs as observed with JWST's or WFIRST's instruments.
+WebbPSF is a Python package that computes simulated point spread functions (PSFs) for NASA's James Webb Space Telescope (JWST) and Nancy Grace Roman Space Telescope (formerly WFIRST). WebbPSF transforms models of telescope and instrument optical state into PSFs, taking into account detector pixel scales, rotations, filter profiles, and point source spectra. It is *not* a full optical model of JWST, but rather a tool for transforming optical path difference (OPD) maps, created with some other tool, into the resulting PSFs as observed with JWST's or WFIRST's instruments.
 
 .. figure:: ./fig_instrument_comparison.png
    :scale: 45 %

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,7 +1,7 @@
 Documentation for WebbPSF
 ===============================
 
-WebbPSF is a Python package that computes simulated point spread functions (PSFs) for NASA's JWST and WFIRST observatories. WebbPSF transforms models of telescope and instrument optical state into PSFs, taking into account detector pixel scales, rotations, filter profiles, and point source spectra. It is *not* a full optical model of JWST, but rather a tool for transforming optical path difference (OPD) maps, created with some other tool, into the resulting PSFs as observed with JWST's or WFIRST's instruments.
+WebbPSF is a Python package that computes simulated point spread functions (PSFs) for NASA's James Webb Space Telescope (JWST) and Nancy Grace Roman Telescope (formerly WFIRST). WebbPSF transforms models of telescope and instrument optical state into PSFs, taking into account detector pixel scales, rotations, filter profiles, and point source spectra. It is *not* a full optical model of JWST, but rather a tool for transforming optical path difference (OPD) maps, created with some other tool, into the resulting PSFs as observed with JWST's or WFIRST's instruments.
 
 .. figure:: ./fig_instrument_comparison.png
    :scale: 45 %

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -3,7 +3,7 @@ Introduction
 
 **What this software does:**
 
-* Uses OPD maps precomputed by detailed optical simulations of JWST and the Nancy Grace Roman Telescope (formerly WFIRST), and in the case of JWST
+* Uses OPD maps precomputed by detailed optical simulations of JWST and the Nancy Grace Roman Space Telescope (formerly WFIRST), and in the case of JWST
   based on instrument and telescope flight hardware cryo-vacuum test results.
 * For JWST, computes PSF images with requested properties for any of JWST's instruments. Supports imaging, coronagraphy, and most spectrographic modes with all of JWST's instruments. IFUs are yet to come.
 * For WFIRST, computes PSFs with the Wide Field Imager, based on recent GSFC optical models, including field- and wavelength-dependent aberrations. 

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -3,7 +3,7 @@ Introduction
 
 **What this software does:**
 
-* Uses OPD maps precomputed by detailed optical simulations of JWST and WFIRST, and in the case of JWST
+* Uses OPD maps precomputed by detailed optical simulations of JWST and the Nancy Grace Roman Telescope (formerly WFIRST), and in the case of JWST
   based on instrument and telescope flight hardware cryo-vacuum test results.
 * For JWST, computes PSF images with requested properties for any of JWST's instruments. Supports imaging, coronagraphy, and most spectrographic modes with all of JWST's instruments. IFUs are yet to come.
 * For WFIRST, computes PSFs with the Wide Field Imager, based on recent GSFC optical models, including field- and wavelength-dependent aberrations. 


### PR DESCRIPTION
I changed the repo's README to use Roman rather than WFIRST in all instances and then changed the first instances of "WFIRST" in the docs, but only for the introduction and index pages since those are usually the ones people go to first.

Let me know if you want any more changes to go in now vs when we wait for the full docs/code update.