### PR TITLE
Fix API not building in docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -42,7 +42,7 @@ conf = ConfigParser()
 
 
 def setup(app):
-    app.add_stylesheet("stsci.css")
+    app.add_css_file("stsci.css")
 
 conf.read([os.path.join(os.path.dirname(__file__), '..', 'setup.cfg')])
 setup_cfg = dict(conf.items('metadata'))

--- a/webbpsf/__init__.py
+++ b/webbpsf/__init__.py
@@ -23,8 +23,6 @@ try:
 except ImportError:
     __version__ = ''
 
-__all__ = ['__version__']
-
 __minimum_python_version__ = "3.6"
 
 


### PR DESCRIPTION
The "Detailed API Reference" page of the docs was building incorrectly (the functions/classes weren't being listed). It seemed that when removing `astropy-helpers`, i set `__all__ = ['__version__']` which meant that the `automodapi` package was finding `__version__` as the only function in the package. This setting doesn't seem to be necessary or done by any other repos I could find that had removed A-H. I confirmed that after removing the line, `webbpsf.__version__ `and `webbpsf.version.version` both still return the version number.

I fixed this issue and also replaced a deprecated function. I checked by building the docs on RTD and confirmed that the API page now looks good. 