### PR TITLE
Update thermal slew scaling

### DIFF
--- a/webbpsf/opds.py
+++ b/webbpsf/opds.py
@@ -1855,7 +1855,9 @@ class OTE_Linear_Model_WSS(OPD):
             segment name will fits 9 Hexikes to that segment
         """
         if not self.scaling:
-            scaling = np.sin(np.radians(self.end_angle) - np.radians(self.start_angle)) / np.sin(np.radians(45.) - np.radians(-5.))
+            num = np.sin(np.radians(self.end_angle)) - np.sin(np.radians(self.start_angle))
+            den = np.sin(np.radians(45.)) - np.sin(np.radians(-5.))
+            scaling = num / den
 
         else:
             scaling = self.scaling


### PR DESCRIPTION
Previous thermal slew scaling equation did not have cumulative totals equal to 1.0 if broken down into smaller jumps (e.g., -5 to 20 deg, then 20 to 45 deg would have a total scaling greater than -5 to 45 deg). Updated equation fixes this issue by taking into account the sin of specific start and end angles rather than just delta angles.