### PR TITLE
Toward better OTE field dependence modeling: use OTE linear model class by default 

### DIFF
--- a/webbpsf/opds.py
+++ b/webbpsf/opds.py
@@ -556,7 +556,7 @@ class OTE_Linear_Model_Elliott(OPD):
 
     """
 
-    def __init__(self, opd=None, opd_index=0, transmission=None, rm_ptt=False, zero=False):
+    def __init__(self, opd=None, opd_index=0, transmission=None, rm_ptt=False, rm_piston=False, zero=False):
         """
         Parameters
         ----------
@@ -571,6 +571,8 @@ class OTE_Linear_Model_Elliott(OPD):
             wherever is nonzero in the OPD file.
         rm_ptt : bool
             Remove piston, tip and tilt from all segments if set. Default is False.
+        rm_piston : bool
+            Remove piston only from all segments if set. Default is False
         zero : bool
             If set, reate an OPD which is precisely zero in all locations. Default is False.
 
@@ -582,6 +584,7 @@ class OTE_Linear_Model_Elliott(OPD):
         self._sensitivities = astropy.table.Table.read(os.path.join(__location__, 'otelm', 'seg_sens.txt'), format='ascii', delimiter='\t')
         self.state = {}
         self.remove_piston_tip_tilt = rm_ptt
+        self.remove_piston_only = rm_piston
 
         self._opd_original = self.opd.copy()
         if zero:
@@ -788,6 +791,9 @@ class OTE_Linear_Model_Elliott(OPD):
 
         if self.remove_piston_tip_tilt:
             zernike_coeffs[0:3] = 0
+        elif self.remove_piston_only:
+            zernike_coeffs[0] = 0
+
         for i in range(len(zernike_coeffs)):
             zern = zernike.zernike1(i + 1, rho=Rw, theta=theta) * zernike_coeffs[i]
             self.opd[wseg] += zern
@@ -1052,7 +1058,7 @@ class OTE_Linear_Model_WSS(OPD):
     """
 
     def __init__(self, name='Unnamed OPD', opd=None, opd_index=0, transmission=None, segment_mask_file='JWpupil_segments.fits',
-                 zero=False, rm_ptt=False, v2v3=None):
+                 zero=False, rm_ptt=False, rm_piston=False, v2v3=None):
         """
         Parameters
         ----------
@@ -1099,6 +1105,7 @@ class OTE_Linear_Model_WSS(OPD):
 
         self._opd_original = self.opd.copy()  # make a separate copy
         self.remove_piston_tip_tilt = rm_ptt
+        self.remove_piston_only = rm_piston
         # Arbitrary additional perturbations can be added, ad hoc, as either Zernike or Hexike coefficients over the
         # whole primary. Use move_global_zernikes for a convenient interface to this.
         self._global_zernike_coeffs = np.zeros(15)

--- a/webbpsf/utils.py
+++ b/webbpsf/utils.py
@@ -313,7 +313,12 @@ def system_diagnostic():
 
     try:
         import pyfftw
-        pyfftw_version = pyfftw.version
+        try:
+            pyfftw_version = pyfftw.__version__
+        except AttributeError:
+            # Back compatibility: Handle older versions with nonstandard version attribute name
+            pyfftw_version = pyfftw.version
+
     except ImportError:
         pyfftw_version = 'not found'
 

--- a/webbpsf/webbpsf_core.py
+++ b/webbpsf/webbpsf_core.py
@@ -463,7 +463,7 @@ class SpaceTelescopeInstrument(poppy.instrument.Instrument):
         if 'defocus_waves' in options:
             defocus_waves = options['defocus_waves']
             defocus_wavelength = float(options['defocus_wavelength']) if 'defocus_wavelength' in options else 2.0e-6
-            _log.info("Adding defocus of %d waves at %.2f microns" % (defocus_waves, defocus_wavelength * 1e6))
+            _log.info(f"Adding defocus of {defocus_waves:.3f} waves at {defocus_wavelength*1e6:.3f} microns" )
             lens = poppy.ThinLens(
                 name='Defocus',
                 nwaves=defocus_waves,

--- a/webbpsf/webbpsf_core.py
+++ b/webbpsf/webbpsf_core.py
@@ -434,6 +434,9 @@ class SpaceTelescopeInstrument(poppy.instrument.Instrument):
 
         pupil_rms_wfe_nm = np.sqrt(np.mean(pupil_optic.opd[pupil_optic.amplitude == 1] ** 2)) * 1e9
         self._extra_keywords['TEL_WFE'] = (pupil_rms_wfe_nm, '[nm] Telescope pupil RMS wavefront error')
+        if hasattr(pupil_optic, 'header_keywords'):
+            self._extra_keywords.update(pupil_optic.header_keywords())
+
         self.pupil_radius = pupil_optic.pupil_diam / 2.0
 
         # add coord transform from entrance pupil to exit pupil

--- a/webbpsf/webbpsf_core.py
+++ b/webbpsf/webbpsf_core.py
@@ -551,7 +551,7 @@ class SpaceTelescopeInstrument(poppy.instrument.Instrument):
                                "instrument class or by setting self.pupil")
         if isinstance(self.pupil, poppy.OpticalElement):
             # supply to POPPY as-is
-            pupil_optic = optsys.add_pupil(self.pupil)
+            pupil_optic = self.pupil
         else:
             # wrap in an optic and supply to POPPY
             if isinstance(self.pupil, str):  # simple filename
@@ -874,7 +874,7 @@ class JWInstrument(SpaceTelescopeInstrument):
                                "instrument class or by setting self.pupil")
         if isinstance(self.pupil, poppy.OpticalElement):
             # supply to POPPY as-is
-            pupil_optic = optsys.add_pupil(self.pupil)
+            pupil_optic = self.pupil
         else:
             # wrap in an optic and supply to POPPY
             if isinstance(self.pupil, str):  # simple filename

--- a/webbpsf/webbpsf_core.py
+++ b/webbpsf/webbpsf_core.py
@@ -844,6 +844,11 @@ class JWInstrument(SpaceTelescopeInstrument):
     def _get_telescope_pupil_and_aberrations(self):
         """return OpticalElement modeling wavefront aberrations for the telescope.
 
+        This is nearly identical to the version of this function in SpaceTelescopeInstrument, differing only at the
+        very end. Here, we load the selected OPD file from disk into an instance of opds.OTE_Linear_Model_WSS if possible.
+        It falls back to a plain FITSOpticalElement for nonstandard sizes of input pupil, since the linear model is not
+        yet generalized to work on arbitrary sizes of pupil other than 1024 pixels.
+
         See also get_aberrations for the SI aberrations.
         """
 

--- a/webbpsf/webbpsf_core.py
+++ b/webbpsf/webbpsf_core.py
@@ -428,52 +428,10 @@ class SpaceTelescopeInstrument(poppy.instrument.Instrument):
         if 'source_offset_theta' in options:
             optsys.source_offset_theta = options['source_offset_theta']
 
-        # ---- set pupil OPD
-        if isinstance(self.pupilopd, str):  # simple filename
-            opd_map = self.pupilopd if os.path.exists(self.pupilopd) else \
-                      os.path.join(self._datapath, "OPD", self.pupilopd)
-        elif hasattr(self.pupilopd, '__getitem__') and isinstance(self.pupilopd[0], str):
-            # tuple with filename and slice
-            opd_map = (self.pupilopd[0] if os.path.exists(self.pupilopd[0])
-                       else os.path.join(self._datapath, "OPD", self.pupilopd[0]),
-                       self.pupilopd[1])
-        elif isinstance(self.pupilopd, (fits.HDUList, poppy.OpticalElement)):
-            opd_map = self.pupilopd  # not a path per se but this works correctly to pass it to poppy
-        elif self.pupilopd is None:
-            opd_map = None
-        else:
-            raise TypeError("Not sure what to do with a pupilopd of that type:" + str(type(self.pupilopd)))
+        # Telescope entrance pupil
+        pupil_optic = self._get_telescope_pupil_and_aberrations()
+        optsys.add_pupil(pupil_optic)
 
-        # ---- set pupil intensity
-        if self.pupil is None:
-            raise RuntimeError("The pupil shape must be specified in the "
-                               "instrument class or by setting self.pupil")
-        if isinstance(self.pupil, poppy.OpticalElement):
-            # supply to POPPY as-is
-            pupil_optic = optsys.add_pupil(self.pupil)
-        else:
-            # wrap in an optic and supply to POPPY
-            if isinstance(self.pupil, str):  # simple filename
-                if os.path.exists(self.pupil):
-                    pupil_transmission = self.pupil
-                else:
-                    pupil_transmission = os.path.join(
-                        self._WebbPSF_basepath,
-                        self.pupil
-                    )
-            elif isinstance(self.pupil, fits.HDUList):
-                # POPPY can use self.pupil as-is
-                pupil_transmission = self.pupil
-            else:
-                raise TypeError("Not sure what to do with a pupil of "
-                                "that type: {}".format(type(self.pupil)))
-            # ---- apply pupil intensity and OPD to the optical model
-            pupil_optic = optsys.add_pupil(
-                name='{} Entrance Pupil'.format(self.telescope),
-                transmission=pupil_transmission,
-                opd=opd_map,
-                # rotation=self._rotation
-            )
         pupil_rms_wfe_nm = np.sqrt(np.mean(pupil_optic.opd[pupil_optic.amplitude == 1] ** 2)) * 1e9
         self._extra_keywords['TEL_WFE'] = (pupil_rms_wfe_nm, '[nm] Telescope pupil RMS wavefront error')
         self.pupil_radius = pupil_optic.pupil_diam / 2.0
@@ -564,6 +522,61 @@ class SpaceTelescopeInstrument(poppy.instrument.Instrument):
                 pass
 
         return optsys
+
+    def _get_telescope_pupil_and_aberrations(self):
+        """return OpticalElement modeling wavefront aberrations for the telescope.
+
+        See also get_aberrations for the SI aberrations.
+        """
+
+        # ---- set pupil OPD
+        if isinstance(self.pupilopd, str):  # simple filename
+            opd_map = self.pupilopd if os.path.exists(self.pupilopd) else \
+                      os.path.join(self._datapath, "OPD", self.pupilopd)
+        elif hasattr(self.pupilopd, '__getitem__') and isinstance(self.pupilopd[0], str):
+            # tuple with filename and slice
+            opd_map = (self.pupilopd[0] if os.path.exists(self.pupilopd[0])
+                       else os.path.join(self._datapath, "OPD", self.pupilopd[0]),
+                       self.pupilopd[1])
+        elif isinstance(self.pupilopd, (fits.HDUList, poppy.OpticalElement)):
+            opd_map = self.pupilopd  # not a path per se but this works correctly to pass it to poppy
+        elif self.pupilopd is None:
+            opd_map = None
+        else:
+            raise TypeError("Not sure what to do with a pupilopd of that type:" + str(type(self.pupilopd)))
+
+        # ---- set pupil intensity
+        if self.pupil is None:
+            raise RuntimeError("The pupil shape must be specified in the "
+                               "instrument class or by setting self.pupil")
+        if isinstance(self.pupil, poppy.OpticalElement):
+            # supply to POPPY as-is
+            pupil_optic = optsys.add_pupil(self.pupil)
+        else:
+            # wrap in an optic and supply to POPPY
+            if isinstance(self.pupil, str):  # simple filename
+                if os.path.exists(self.pupil):
+                    pupil_transmission = self.pupil
+                else:
+                    pupil_transmission = os.path.join(
+                        self._WebbPSF_basepath,
+                        self.pupil
+                    )
+            elif isinstance(self.pupil, fits.HDUList):
+                # POPPY can use self.pupil as-is
+                pupil_transmission = self.pupil
+            else:
+                raise TypeError("Not sure what to do with a pupil of "
+                                "that type: {}".format(type(self.pupil)))
+            # ---- apply pupil intensity and OPD to the optical model
+            pupil_optic = poppy.FITSOpticalElement(
+                name='{} Entrance Pupil'.format(self.telescope),
+                transmission=pupil_transmission,
+                opd=opd_map,
+                planetype=poppy.poppy_core.PlaneType.pupil
+                # rotation=self._rotation
+            )
+        return pupil_optic
 
     def _addAdditionalOptics(self, optsys, oversample=2):
         """Add instrument-internal optics to an optical system, typically coronagraphic or
@@ -809,22 +822,93 @@ class JWInstrument(SpaceTelescopeInstrument):
                                                               detector_oversample=detector_oversample,
                                                               fov_arcsec=fov_arcsec, fov_pixels=fov_pixels,
                                                               options=options)
+        # If the OTE model in the entrance pupil is a plain FITSOpticalElement, cast it to the linear model class
+        if not isinstance(optsys.planes[0], opds.OTE_Linear_Model_WSS):
+            lom_ote = opds.OTE_Linear_Model_WSS()
+            lom_ote
+
         optsys.planes[0].display_annotate = utils.annotate_ote_entrance_coords
         return optsys
 
     def _get_aberrations(self):
-        """ Compute field-dependent aberration for a given instrument
-        based on a lookup table of Zernike coefficients derived from
+        """ return OpticalElement modeling wavefront aberrations for a given instrument,
+        including field dependence based on a lookup table of Zernike coefficients derived from
         ISIM cryovac test data.
-
-        This is a very preliminary version!
         """
         if not self.include_si_wfe:
             return None
 
         optic = self._si_wfe_class(self)
-
         return optic
+
+    def _get_telescope_pupil_and_aberrations(self):
+        """return OpticalElement modeling wavefront aberrations for the telescope.
+
+        See also get_aberrations for the SI aberrations.
+        """
+
+        # ---- set pupil OPD
+        if isinstance(self.pupilopd, str):  # simple filename
+            opd_map = self.pupilopd if os.path.exists(self.pupilopd) else \
+                os.path.join(self._datapath, "OPD", self.pupilopd)
+        elif hasattr(self.pupilopd, '__getitem__') and isinstance(self.pupilopd[0], str):
+            # tuple with filename and slice
+            opd_map = (self.pupilopd[0] if os.path.exists(self.pupilopd[0])
+                       else os.path.join(self._datapath, "OPD", self.pupilopd[0]),
+                       self.pupilopd[1])
+        elif isinstance(self.pupilopd, (fits.HDUList, poppy.OpticalElement)):
+            opd_map = self.pupilopd  # not a path per se but this works correctly to pass it to poppy
+        elif self.pupilopd is None:
+            opd_map = None
+        else:
+            raise TypeError("Not sure what to do with a pupilopd of that type:" + str(type(self.pupilopd)))
+
+        # ---- set pupil intensity
+        if self.pupil is None:
+            raise RuntimeError("The pupil shape must be specified in the "
+                               "instrument class or by setting self.pupil")
+        if isinstance(self.pupil, poppy.OpticalElement):
+            # supply to POPPY as-is
+            pupil_optic = optsys.add_pupil(self.pupil)
+        else:
+            # wrap in an optic and supply to POPPY
+            if isinstance(self.pupil, str):  # simple filename
+                if os.path.exists(self.pupil):
+                    pupil_transmission = self.pupil
+                else:
+                    pupil_transmission = os.path.join(
+                        self._WebbPSF_basepath,
+                        self.pupil
+                    )
+            elif isinstance(self.pupil, fits.HDUList):
+                # POPPY can use self.pupil as-is
+                pupil_transmission = self.pupil
+            else:
+                raise TypeError("Not sure what to do with a pupil of "
+                                "that type: {}".format(type(self.pupil)))
+            # ---- apply pupil intensity and OPD to the optical model
+
+            # TODO - more flexibly be smart about if the pupil size works for the LOM or not...
+
+            if 'npix1024' in pupil_transmission:
+                # The linear model is limited to require 1024 pixels right now, so in this case (the default)
+                # we can use that:
+                pupil_optic = opds.OTE_Linear_Model_WSS(
+                    name='{} Entrance Pupil'.format(self.telescope),
+                    transmission=pupil_transmission,
+                    opd=opd_map,
+                    v2v3=self._tel_coords()
+                )
+            else:
+                _log.warning("Nonstandard resolution pupil, so linear model for OTE mirror moves is not supported")
+                pupil_optic = poppy.FITSOpticalElement(
+                    name='{} Entrance Pupil'.format(self.telescope),
+                    transmission=pupil_transmission,
+                    opd=opd_map,
+                    planetype=poppy.poppy_core.PlaneType.pupil
+                )
+        return pupil_optic
+
 
     @SpaceTelescopeInstrument.aperturename.setter
     def aperturename(self, value):


### PR DESCRIPTION
As discussed in slack: We want to enhance the OTE wavefront model to include models of field dependence over the OTE focal plane (both the nominal as-built WFE in the case of a perfectly aligned telescope, and the potential excess WFE from MIMF aberrations if the SM is misaligned). 

- [x] As a practical note this is going to be easier to implement if all the linear models for the OTE are in one class. This PR refactors the JWST models to by default automatically cast the wavefront error read from disk (the predicted or requirements WFE files) into the OTE_Linear_Model_WSS class, instead of a plain FITSOpticalElement. This happens behind the scenes with no need for any change in user code. 
The exceptional to this is, the OTE linear model does not yet support anything other than the default npix=1024 pupil array size, so if any other pupil size is selected for the input model we fall back to the plain FITSOpticalElement. This limitation would be nice to remove but is out of scope for this PR. 
- [x] I add a placeholder method OTE_Linear_Model_WSS._apply_field_dependence_model(), which currently does nothing yet but which we can & will implement with the necessary Zernike calculations. 
- [x] I also fixed a couple unrelated minor issues that I noticed while testing this: a change in the pyfftw version string that was causing problems for a unit test, and improving a log string to show a reasonable number of significant figures. (Unrelated to the core of this PR but not worth the effort to split into a separate PR)