### PR TITLE
Proof of Concept: override_aberrations function for WFIRST (Roman)

### DIFF
--- a/webbpsf/wfirst.py
+++ b/webbpsf/wfirst.py
@@ -563,7 +563,7 @@ class WFI(WFIRSTInstrument):
         self._is_custom_aberrations = True
 
     def reset_override_aberrations(self):
-        """Release detector aberrations override and load default for active filter"""
+        """Release detector aberrations override and loads default"""
         self._detectors = _load_wfi_detector_aberrations(os.path.join(self._datapath, 'wim_zernikes_cycle8.csv'))
         self._is_custom_aberrations = False
 

--- a/webbpsf/wfirst.py
+++ b/webbpsf/wfirst.py
@@ -477,6 +477,7 @@ class WFI(WFIRSTInstrument):
 
         self.pupil_mask_list = self._pupil_controller.pupil_mask_list
 
+        self._is_custom_detectors = False
         self._detector_npixels = 4096
         self._detectors = _load_wfi_detector_aberrations(os.path.join(self._datapath, 'wim_zernikes_cycle8.csv'))
         assert len(self._detectors.keys()) > 0
@@ -555,6 +556,16 @@ class WFI(WFIRSTInstrument):
     @property
     def _masked_pupil_path(self):
         return self._pupil_controller._masked_pupil_path
+
+    def override_detector(self, path):
+        """Override detector aberrations"""
+        self._detectors = _load_wfi_detector_aberrations(path)
+        self._is_custom_detectors = True
+
+    def reset_override_detector(self):
+        """Release detector aberrations override and load default for active filter"""
+        self._detectors = _load_wfi_detector_aberrations(os.path.join(self._datapath, 'wim_zernikes_cycle8.csv'))
+        self._is_custom_detectors = False
 
 
 class CGI(WFIRSTInstrument):

--- a/webbpsf/wfirst.py
+++ b/webbpsf/wfirst.py
@@ -477,7 +477,7 @@ class WFI(WFIRSTInstrument):
 
         self.pupil_mask_list = self._pupil_controller.pupil_mask_list
 
-        self._is_custom_detectors = False
+        self._is_custom_aberrations = False
         self._detector_npixels = 4096
         self._detectors = _load_wfi_detector_aberrations(os.path.join(self._datapath, 'wim_zernikes_cycle8.csv'))
         assert len(self._detectors.keys()) > 0
@@ -560,12 +560,12 @@ class WFI(WFIRSTInstrument):
     def override_aberrations(self, path):
         """Override detector aberrations"""
         self._detectors = _load_wfi_detector_aberrations(path)
-        self._is_custom_detectors = True
+        self._is_custom_aberrations = True
 
-    def override_aberrations(self):
+    def reset_override_aberrations(self):
         """Release detector aberrations override and load default for active filter"""
         self._detectors = _load_wfi_detector_aberrations(os.path.join(self._datapath, 'wim_zernikes_cycle8.csv'))
-        self._is_custom_detectors = False
+        self._is_custom_aberrations = False
 
 
 class CGI(WFIRSTInstrument):

--- a/webbpsf/wfirst.py
+++ b/webbpsf/wfirst.py
@@ -557,12 +557,12 @@ class WFI(WFIRSTInstrument):
     def _masked_pupil_path(self):
         return self._pupil_controller._masked_pupil_path
 
-    def override_detector(self, path):
+    def override_aberrations(self, path):
         """Override detector aberrations"""
         self._detectors = _load_wfi_detector_aberrations(path)
         self._is_custom_detectors = True
 
-    def reset_override_detector(self):
+    def override_aberrations(self):
         """Release detector aberrations override and load default for active filter"""
         self._detectors = _load_wfi_detector_aberrations(os.path.join(self._datapath, 'wim_zernikes_cycle8.csv'))
         self._is_custom_detectors = False


### PR DESCRIPTION
There was an urgent request to make overriding the WFIRST/Roman detector aberrations data possible. This was initially planned to be a part of the WFIRST/Roman prism and grsim implementation. The current plan is to make this functionality available via @robelgeda's `override_detector` branch until the WFIRST/Roman prism and grsim implementation is complete. This PR  gives an overview of what is being provided in that branch which is a temporary means to satisfy the feature request. This PR may be closed when the initial prism and grism PR is opened. 

This branch will be closed once the prism and grsim PR is opened.