### PR TITLE
update syntax to remove unnecessary underscores after poppy PR 386

### DIFF
--- a/webbpsf/tests/test_nircam.py
+++ b/webbpsf/tests/test_nircam.py
@@ -354,7 +354,7 @@ def test_ways_to_specify_weak_lenses():
         nrc.pupil_mask = pup
         if filt is not None: nrc.filter = filt
 
-        assert expected in [p.name for p in nrc._get_optical_system().planes], "Optical system did not contain expected plane {} for {}, {}".format(expected, filt, pup)
+        assert expected in [p.name for p in nrc.get_optical_system().planes], "Optical system did not contain expected plane {} for {}, {}".format(expected, filt, pup)
 
 
 def test_nircam_coron_wfe_offset(fov_pix=15, oversample=2, fit_gaussian=True):

--- a/webbpsf/tests/test_webbpsf.py
+++ b/webbpsf/tests/test_webbpsf.py
@@ -183,7 +183,7 @@ def test_return_intermediates():
     nc.image_mask='maskswb'
     nc.pupil_mask='wedgelyot'
 
-    osys = nc._get_optical_system()
+    osys = nc.get_optical_system()
 
     psf, intermediates = nc.calc_psf(monochromatic=2e-6, return_intermediates=True)
     assert len(intermediates) == len(osys.planes)

--- a/webbpsf/tests/test_wfirst.py
+++ b/webbpsf/tests/test_wfirst.py
@@ -154,7 +154,7 @@ def test_WFI_detector_position_setter():
 def test_WFI_includes_aberrations():
     wfi = wfirst.WFI()
     wfi.detector = 'SCA01'
-    osys = wfi._get_optical_system()
+    osys = wfi.get_optical_system()
     assert isinstance(osys[2], wfirst.FieldDependentAberration), (
         "Third plane of WFIRST WFI optical system should be the "
         "field dependent aberration virtual optic"

--- a/webbpsf/tests/validate_webbpsf.py
+++ b/webbpsf/tests/validate_webbpsf.py
@@ -388,7 +388,7 @@ def validate_vs_krist_blc(which='spot'):
     mask1f = fits.open(mask1)
 
     #P.subplot(332)
-    os = nc._get_optical_system()
+    os = nc.get_optical_system()
     #os.planes[1].display(ax=P.gca(),  what='intensity', colorbar_orientation='vertical')
     #P.gca().set_title('')
     #P.gca().set_xbound(-8,8)
@@ -471,7 +471,7 @@ def validate_vs_krist_sims(clobber=False, normalize=False, which='spot', no_sam=
     poppy.display_PSF(mask1f, title="", pixelscale='PIXSIZE', vmin=0, vmax=1, scale='linear', cmap=matplotlib.cm.gray)
 
     P.subplot(332)
-    os = nc._get_optical_system()
+    os = nc.get_optical_system()
     os.planes[1].display(ax=P.gca(),  what='intensity', colorbar_orientation='vertical')
     P.gca().set_title('')
     P.gca().set_xbound(-8,8)

--- a/webbpsf/webbpsf_core.py
+++ b/webbpsf/webbpsf_core.py
@@ -193,7 +193,7 @@ class SpaceTelescopeInstrument(poppy.instrument.Instrument):
         fits.HDUList object corresponding to such a file. If the file contains a
         datacube, you may set this to a tuple (filename, slice) to select a
         given slice, or else the first slice will be used."""
-        self.pupil_radius = None  # Set when loading FITS file in _get_optical_system
+        self.pupil_radius = None  # Set when loading FITS file in get_optical_system
 
         self.options = {}  # dict for storing other arbitrary options.
 
@@ -370,7 +370,7 @@ class SpaceTelescopeInstrument(poppy.instrument.Instrument):
         else:
             poppy.Instrument._calc_psf_format_output(self, result, options)
 
-    def _get_optical_system(self, fft_oversample=2, detector_oversample=None,
+    def get_optical_system(self, fft_oversample=2, detector_oversample=None,
                             fov_arcsec=2, fov_pixels=None, options=None):
         """ Return an OpticalSystem instance corresponding to the instrument as currently configured.
 
@@ -817,10 +817,10 @@ class JWInstrument(SpaceTelescopeInstrument):
         """ Return default FOV in arcseconds """
         return 5  # default for all NIR instruments
 
-    def _get_optical_system(self, fft_oversample=2, detector_oversample=None, fov_arcsec=2, fov_pixels=None, options=None):
+    def get_optical_system(self, fft_oversample=2, detector_oversample=None, fov_arcsec=2, fov_pixels=None, options=None):
         # invoke superclass version of this
         # then add a few display tweaks
-        optsys = SpaceTelescopeInstrument._get_optical_system(self,
+        optsys = SpaceTelescopeInstrument.get_optical_system(self,
                                                               fft_oversample=fft_oversample,
                                                               detector_oversample=detector_oversample,
                                                               fov_arcsec=fov_arcsec, fov_pixels=fov_pixels,
@@ -1406,7 +1406,7 @@ class MIRI(JWInstrument):
         # telescope pupil. Likewise the LRS grism is rotated but its pupil stop is not.
         #
         # We model this by just not rotating till after the coronagraph. Thus we need to
-        # un-rotate the primary that was already created in _get_optical_system.
+        # un-rotate the primary that was already created in get_optical_system.
         # This approach is required computationally so we can work in an unrotated frame
         # aligned with the FQPM axes.
 

--- a/webbpsf/wfirst.py
+++ b/webbpsf/wfirst.py
@@ -267,7 +267,7 @@ class WFIRSTInstrument(webbpsf_core.SpaceTelescopeInstrument):
 
     def _get_aberrations(self):
         """Get the OpticalElement that applies the field-dependent
-        optical aberrations. (Called in _get_optical_system.)"""
+        optical aberrations. (Called in get_optical_system.)"""
         return self._detectors[self._detector]
 
     def _get_fits_header(self, result, options):
@@ -813,7 +813,7 @@ class CGI(WFIRSTInstrument):
 
     def _get_aberrations(self):
         """Get the OpticalElement that applies the field-dependent
-        optical aberrations. (Called in _get_optical_system.)"""
+        optical aberrations. (Called in get_optical_system.)"""
         return None
 
     def _get_fits_header(self, result, options):


### PR DESCRIPTION
Update to remove now-unnecessary underscores before the `[_]get_optical_system` function.

Needed to fix failing tests after https://github.com/spacetelescope/poppy/pull/386