### PR TITLE
update opd thermal slew test, in particular for a change in pupil segment data file

### DIFF
--- a/webbpsf/opds.py
+++ b/webbpsf/opds.py
@@ -123,6 +123,7 @@ class OPD(poppy.FITSOpticalElement):
 
         full_seg_mask_file = os.path.join(utils.get_webbpsf_data_path(), segment_mask_file)
         self._segment_masks = fits.getdata(full_seg_mask_file)
+        self._segment_masks_version = fits.getheader(full_seg_mask_file)['VERSION']
 
         # Where are the centers of each segment?  From OTE design geometry
         self._seg_centers_m = {seg[0:2]: np.asarray(cen)


### PR DESCRIPTION
As discussed & debugged on slack with @kjbrooks : a change in the `jwpupil_segment.fits` data file to more accurately handle pixels at segment boundaries (see #393) led to a failing test for the thermal slew OPD.  It's not necessary to maintain precise agreement at floating-point machine precision for this, so the correct fix is to update the test code to a new expected value. I did this, with a check for the data file version to use the right value with or without the updated data files. 

I also added a test check of the OPD's rms as well as the max, so that the test checks more than just a single pixel in the image. This too has an expected value that depends on which data file version is used. 

For the record here's the slight difference in the two data files: 

<img width="1688" alt="jwst_linear_model_segmap_comparison" src="https://user-images.githubusercontent.com/1151745/103812585-b9262500-502c-11eb-9486-9528d057a0e6.png">

