### PR TITLE
Gridded PSF library generation should copy hexike P/T/T keywords, if present

### DIFF
--- a/webbpsf/gridded_library.py
+++ b/webbpsf/gridded_library.py
@@ -343,6 +343,16 @@ class CreatePSFLibrary:
             meta["NORMALIZ"] = (psf[ext].header["NORMALIZ"], "PSF normalization method")
             meta["TEL_WFE"] = (psf[ext].header["TEL_WFE"], "[nm] Telescope pupil RMS wavefront error")
 
+            # Copy values for per-segment Zernike {piston, tip, tilt}, if present
+            # (these are only present or used in incoherent segment PSF generation with the
+            # remove_piston_tip_tilt value set to True):
+            if 'S01PISTN' in psf[ext].header:
+                # if we have one such keyword, assume we have them for all segments and all types
+                for i in range(1,19):
+                    for ztype in ('PISTN', 'XTILT', 'YTILT'):
+                        mykey = f"S{i:02d}{ztype}"
+                        meta[mykey] = (psf[ext].header[mykey], psf[ext].header.comments[mykey])
+
             # copy all the jitter-related keys (the exact set of keywords varies based on jitter type)
             for k in psf[ext].header.keys():   # do the rest
                 if k.startswith('JITR'):


### PR DESCRIPTION
Fixes an oversight in which the extra FITS keywords that record segment-level hexike piston, tip, tilt were not getting copied to gridded PSF library output files.  

The keywords `S##PISTN`, `S##XTILT`, and `S##YTILT` (where `##` is some segment number) are added during PSF calculations if and only if using the OTE linear model with the `remove_piston_tip_tilt` option set to `True`. This is in order to record the segment tip and tilt values for later use, before removing them in certain calculations such as when generating individual segment PSFs. For this to be used in MIRAGE, we've gotta propagate these values into the gridded PSF library FITS headers too. (which are derived from the base PSF headers, but not all keywords are copied). 

This PR checks if such keywords exist, and if so then it copies 'em all over to the gridded PSF library. 