### PR TITLE
Add a travis test for latest dep versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,9 @@ matrix:
         - env: TOXENV='py37-stable-test'
 
     allow_failures:
+        # Try latest versions of all dependencies
+        - env: TOXENV='py38-latest-test'
+
         # Released POPPY and/or pySIAF may be missing new functionality used by dev WebbPSF
         - env: TOXENV='py37-stable-test'
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,9 @@ matrix:
         # Try Astropy development version
         - env: TOXENV='py38-astropydev-test'
 
+        # Try latest versions of all dependencies
+        - env: TOXENV='py38-latest-test'
+
         # Try minimum supported versions
         - env: TOXENV='py36-legacy36-test'
 
@@ -34,9 +37,6 @@ matrix:
         - env: TOXENV='py37-stable-test'
 
     allow_failures:
-        # Try latest versions of all dependencies
-        - env: TOXENV='py38-latest-test'
-
         # Released POPPY and/or pySIAF may be missing new functionality used by dev WebbPSF
         - env: TOXENV='py37-stable-test'
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@ ipython==7.20.0
 matplotlib==3.3.4
 numpy==1.19.4
 photutils==1.0.2
-poppy==0.9.1
+poppy>=0.9.1
 pysiaf==0.10.0
 scipy==1.6.0

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     py{36,37,38}-test
-    py{36,37,38}-{poppydev,pysiafdev,astropydev,stable}-test
+    py{36,37,38}-{poppydev,pysiafdev,astropydev,latest,stable}-test
     py36-legacy36-test
     py{36,37,38}-{poppydev,pysiafdev}-cov
 
@@ -13,6 +13,7 @@ deps =
     pysiafdev,legacy36,astropydev: git+https://github.com/spacetelescope/pysiaf.git#egg=pysiaf
     legacy36: numpy==1.16.*
     astropydev: git+git://github.com/astropy/astropy
+    latest: -rrequirements.txt
     stable: poppy
     stable: pysiaf
     cov: pytest-astropy

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ envlist =
 passenv = *
 deps =
     pytest
-    poppydev,legacy36,astropydev: git+https://github.com/spacetelescope/poppy.git#egg=poppy
+    poppydev,legacy36,astropydev,latest: git+https://github.com/spacetelescope/poppy.git#egg=poppy
     pysiafdev,legacy36,astropydev: git+https://github.com/spacetelescope/pysiaf.git#egg=pysiaf
     legacy36: numpy==1.16.*
     astropydev: git+git://github.com/astropy/astropy


### PR DESCRIPTION
This PR creates a `travis` test that installs the latest versions of all the dependencies using the `requirements.txt` file. I also updated the `poppy` version in the `requirements.txt` file so that we can run the dev `poppy` for the new test in case the newer `webbpsf` changes aren't compatible with the stable `poppy` version.

We'll need to merge this PR and rebase the open dependabot PR in order to actually have it test the newest requirements.