### PR TITLE
bug fix: avoid matplotlib deprecation of changing colormaps

### DIFF
--- a/webbpsf/opds.py
+++ b/webbpsf/opds.py
@@ -37,6 +37,7 @@ import astropy.io.fits as fits
 import astropy.units as u
 import logging
 from collections import OrderedDict
+import copy
 
 import poppy
 import poppy.zernike as zernike
@@ -336,7 +337,7 @@ class OPD(poppy.FITSOpticalElement):
                 raise RuntimeError("'clear=True' is incompatible with passing in an Axes instance.")
             plt.clf()
         if cmap is None:
-            cmap = matplotlib.cm.get_cmap(poppy.conf.cmap_diverging)
+            cmap = copy.copy(matplotlib.cm.get_cmap(poppy.conf.cmap_diverging))
         cmap.set_bad('0.3')
 
         mask = np.ones_like(self.opd)

--- a/webbpsf/opds.py
+++ b/webbpsf/opds.py
@@ -247,7 +247,7 @@ class OPD(poppy.FITSOpticalElement):
             y = radius * np.sin(t) + ycen
             plt.plot(x, y, **kwargs)
 
-        cmap = matplotlib.cm.get_cmap(poppy.conf.cmap_diverging)
+        cmap = copy.copy(matplotlib.cm.get_cmap(poppy.conf.cmap_diverging))
         cmap.set_bad('0.3')
 
         plt.clf()
@@ -471,7 +471,7 @@ class OPD(poppy.FITSOpticalElement):
         npix = 200
         hexap = zernike.hex_aperture(npix)
         hexap[np.where(hexap == 0)] = np.nan
-        cmap = matplotlib.cm.jet
+        cmap = copy.copy(matplotlib.cm.get_cmap('jet'))
         cmap.set_bad('0.5', alpha=0.0)
 
         for j in np.arange(nzerns) + 1:


### PR DESCRIPTION
Copy colormap before modifying it. Avoids causing a warning about modifying a global colormap, like the following: 
```
2021-02-17 09:03:18,762 - stpipe - WARNING - /home/mperrin/software/webbpsf/webbpsf/opds.py:340: 
MatplotlibDeprecationWarning: You are modifying the state of a globally registered colormap. 
In future versions, you will not be able to modify a registered colormap in-place. To remove this 
warning, you can make a copy of the colormap first. 
cmap = copy.copy(mpl.cm.get_cmap("RdBu_r"))
```

Same issue as https://github.com/spacetelescope/poppy/pull/379, just in a different set of places in the code. 
