### PR TITLE
calculate SI WFE header keyword over just the JWST aperture, not the full array

### DIFF
--- a/webbpsf/webbpsf_core.py
+++ b/webbpsf/webbpsf_core.py
@@ -453,9 +453,13 @@ class SpaceTelescopeInstrument(poppy.instrument.Instrument):
             optsys.add_pupil(aberration_optic)
 
             try:
-                inst_rms_wfe_nm = np.sqrt(np.mean(aberration_optic.opd[aberration_optic.amplitude == 1] ** 2)) * 1e9
+                # Calculate SI WFE over just the OTE entrance pupil aperture,
+                # though with a flip in the Y axis to account for entrance vs. exit pupil conventions
+                exit_pupil_mask = pupil_optic.amplitude[::-1] == 1
+                inst_rms_wfe_nm = np.sqrt(np.mean(aberration_optic.opd[exit_pupil_mask] ** 2)) * 1e9
                 self._extra_keywords['SI_WFE'] = (inst_rms_wfe_nm, '[nm] instrument pupil RMS wavefront error')
-            except TypeError:
+            except (TypeError, IndexError):
+                # Currently the above does not work for Roman, but fixing this is deferred to future work
                 pass
 
             if hasattr(aberration_optic, 'header_keywords'):


### PR DESCRIPTION
Minor fix to header keywords, discovered while cross-checking output PSFs with the lookup table grid. 

The header keyword "SI_WFE" should give the RMS WFE evaluated just over the JWST aperture, not the full SI WFE aperture (which may be a circular aperture circumscribing the JWST pupil, or may be a full array with no mask; either way, that's not what we should use)

This has no effect on the output PSFs at all. It just makes one header keyword a bit more accurate. 