### PR TITLE
JWST Detector Position handling 

### DIFF
--- a/webbpsf/tests/test_miri.py
+++ b/webbpsf/tests/test_miri.py
@@ -68,6 +68,6 @@ def test_miri_aperturename():
     ref_tel_coords = miri._tel_coords()
 
     miri.aperturename = 'MIRIM_SUB256'
-    assert miri.detector_position == (128, 128), "Changing to a subarray aperture didn't change the " \
+    assert miri.detector_position == (128.5, 128.5), "Changing to a subarray aperture didn't change the " \
                                                  "reference pixel coords as expected"
     assert np.any( miri._tel_coords() != ref_tel_coords), "Changing to a subarray aperture didn't change the V2V3 coords as expected."

--- a/webbpsf/tests/test_niriss.py
+++ b/webbpsf/tests/test_niriss.py
@@ -65,7 +65,7 @@ def test_niriss_aperturename():
     ref_tel_coords = niriss._tel_coords()
 
     niriss.aperturename = 'NIS_SUB128'
-    assert niriss.detector_position == (64, 64), "Changing to a subarray aperture didn't change the " \
+    assert niriss.detector_position == (64.5, 64.5), "Changing to a subarray aperture didn't change the " \
                                                  "reference pixel coords as expected"
     assert np.any(
         niriss._tel_coords() != ref_tel_coords), "Changing to a subarray aperture didn't change the V2V3 coords " \

--- a/webbpsf/tests/test_psfgrid.py
+++ b/webbpsf/tests/test_psfgrid.py
@@ -32,8 +32,7 @@ def test_compare_to_calc_psf_oversampled():
     # Pull one of the PSFs out of the grid
     psfnum = 1
     loc = grid.meta["grid_xypos"][psfnum]
-    locy = int(float(loc[1]) - 0.5)
-    locx = int(float(loc[0]) - 0.5)
+    locx, locy = loc
     gridpsf = grid.data[psfnum, :, :]
 
     # Using meta data, create the expected same PSF via calc_psf
@@ -66,8 +65,7 @@ def test_compare_to_calc_psf_detsampled():
     # Pull one of the PSFs out of the grid
     psfnum = 1
     loc = grid.meta["grid_xypos"][psfnum]
-    locy = int(float(loc[1]))
-    locx = int(float(loc[0]))
+    locx, locy = loc
     gridpsf = grid.data[psfnum, :, :]
 
     # Using meta data, create the expected same PSF via calc_psf
@@ -242,8 +240,7 @@ def test_wfi():
     # Pull one of the PSFs out of the grid
     psfnum = 1
     loc = grid.meta["grid_xypos"][psfnum]
-    locy = int(float(loc[1])-0.5)
-    locx = int(float(loc[0])-0.5)
+    locx, locy = loc
     gridpsf = grid.data[psfnum, :, :]
 
     # Using meta data, create the expected same PSF via calc_psf

--- a/webbpsf/webbpsf_core.py
+++ b/webbpsf/webbpsf_core.py
@@ -828,6 +828,11 @@ class JWInstrument(SpaceTelescopeInstrument):
             x, y = map(float, position)
         except ValueError:
             raise ValueError("Detector pixel coordinates must be a pair of floats, not {}".format(position))
+
+        npix = self._detector_npixels
+        if (x < 0) or (y < 0) or (x >= npix) or (y >= npix):
+            _log.warning(f"Detector pixel coordinates are outside of detector region ({x:.2f}, {y:.2f})")
+
         self._detector_position = x, y
 
     def get_optical_system(self, fft_oversample=2, detector_oversample=None, fov_arcsec=2, fov_pixels=None, options=None):


### PR DESCRIPTION
While updating the distortion grid, I realized that WebbPSF always converts the specified detector positions to ints and restricts boundaries within the detector pixels box. However, since these values correspond to SIAF aperture 'sci' coords and are primarily used to convert to 'tel' (V2/V3), converting to ints prevents precise transformations between the 'idl' and 'tel' coordinate systems. Indeed, the automatic SIAF aperture look-up many time specifies fractional numbers, that then get converted to ints. This makes it confusing when applying the header information to SIAF transformations, especially if one wants to track the small sub-pixel shifts for coronagraphic masks.

In addition, there's very little reason to constrain to the box of detector pixels, because it is possible to simulate PSFs outside this region (ie., SI WFE extrapolation). Instead of raising a ValueError, I just print a warning to alert the user in case they are unaware.

JWST instrument tests have been updated to account for fractional PSFs.