### PR TITLE
update data files release script

### DIFF
--- a/dev_utils/make-minimal-datafiles.py
+++ b/dev_utils/make-minimal-datafiles.py
@@ -43,8 +43,10 @@ for instr in insts:
     f0.close()
 
 print("#### Removing extra optional pupil files ####")
-os.remove(os.path.join(WORKING_DIR, 'webbpsf-data','jwst_pupil_revW_npix2048.fits.gz'))
-os.remove(os.path.join(WORKING_DIR, 'webbpsf-data','jwst_pupil_revW_npix16384.fits.gz'))
+# keep just the 1024 and 2048 ones for tests; don't need the rest
+os.remove(os.path.join(WORKING_DIR, 'webbpsf-data','jwst_pupil_RevW_npix4096.fits.gz'))
+os.remove(os.path.join(WORKING_DIR, 'webbpsf-data','jwst_pupil_RevW_npix16384.fits.gz'))
+os.remove(os.path.join(WORKING_DIR, 'webbpsf-data','JWpupil_segments_RevW_npix4096.fits.gz'))
 os.remove(os.path.join(WORKING_DIR, 'webbpsf-data','tricontagon.fits.gz'))
 
 print("#### Creating tar file ####")

--- a/dev_utils/master_data_release.sh
+++ b/dev_utils/master_data_release.sh
@@ -17,12 +17,14 @@ TMPDIR="/tmp/webbpsf-data"
 ./make-minimal-datafiles.py  ${PWD}/webbpsf-data-${VER}.tar.gz
 
 
-echo "Copying webbpsf-data-${VER}.tar.gz   ==>>  /grp/webpages/mperrin/software/webbpsf"
-\cp ${PWD}/webbpsf-data-${VER}.tar.gz /grp/webpages/mperrin/software/webbpsf
-
-
-echo "Copying minimal-webbpsf-data.tar.gz   ==>> /grp/webpages/mperrin/software/webbpsf"
-\cp /Users/mperrin/tmp/minimal-webbpsf-data/minimal-webbpsf-data.tar.gz /grp/webpages/mperrin/software/webbpsf
-
-
+echo
+echo "================================================="
+echo "OUTPUT FILES:"
+echo
+echo ${PWD}/webbpsf-data-${VER}.tar.gz
+echo ~/tmp/minimal-webbpsf-data/minimal-webbpsf-data.tar.gz
+echo
+echo You probably want to test if those look as expected, and if so then copy into the Box folder 'webbpsf_data_public'
+echo "================================================="
+echo
 


### PR DESCRIPTION
FYI @shanosborne @kjbrooks 

Update data files release script to 

1. Include the 1024 and 2048-sized pupil files in the minimal data zip we use for Travis CI, while still exclude the larger files
2. Update the master script for where the files should go after being created.