### PR TITLE
Streamline CI test runtimes

### DIFF
--- a/webbpsf/tests/test_opds.py
+++ b/webbpsf/tests/test_opds.py
@@ -456,7 +456,7 @@ def test_changing_npix():
     # Create a NIRCam instance using the default npix=1024
     nircam_1024 = webbpsf.NIRCam()
     nircam_1024.pupilopd = None # Set to none so I don't have to worry about making new OPDs
-    psf_1024 = nircam_1024.calc_psf(oversample=2)
+    psf_1024 = nircam_1024.calc_psf(oversample=2, nlambda=1, add_distortion=False)
 
     # Create a NIRCam instance using npix=2048
     npix = 2048
@@ -464,7 +464,7 @@ def test_changing_npix():
     nircam_2048.pupil = os.path.join(webbpsf.utils.get_webbpsf_data_path(),
                                      f'jwst_pupil_RevW_npix{npix}.fits.gz')
     nircam_2048.pupilopd = None # Set to none so I don't have to worry about making new OPDs
-    psf_2048 = nircam_2048.calc_psf(oversample=2)
+    psf_2048 = nircam_2048.calc_psf(oversample=2, nlambda=1, add_distortion=False)
 
     # Let's check individual pixel values, at least where the PSF is not too dim.
     # Check all pixels which have > 1e-6 of the total flux (we can safely ignore pixels with very low intensity)

--- a/webbpsf/tests/test_psfgrid.py
+++ b/webbpsf/tests/test_psfgrid.py
@@ -23,11 +23,12 @@ def test_compare_to_calc_psf_oversampled():
     """
     oversample = 2
     fov_pixels = 10
+    nlambda= 1
 
     # Create PSF grid
     fgs = webbpsf_core.FGS()
     fgs.detector = "FGS1"
-    grid = fgs.psf_grid(all_detectors=False, num_psfs=4, oversample=oversample, fov_pixels=fov_pixels)
+    grid = fgs.psf_grid(all_detectors=False, num_psfs=4, oversample=oversample, fov_pixels=fov_pixels, nlambda=nlambda)
 
     # Pull one of the PSFs out of the grid
     psfnum = 1
@@ -38,7 +39,7 @@ def test_compare_to_calc_psf_oversampled():
 
     # Using meta data, create the expected same PSF via calc_psf
     fgs.detector_position = (locx, locy)
-    calcpsf = fgs.calc_psf(oversample=oversample, fov_pixels=fov_pixels)["OVERDIST"].data
+    calcpsf = fgs.calc_psf(oversample=oversample, fov_pixels=fov_pixels, nlambda=nlambda)["OVERDIST"].data
     kernel = astropy.convolution.Box2DKernel(width=oversample)
     convpsf = astropy.convolution.convolve(calcpsf, kernel)
     scalefactor = oversample**2 # normalization as used internally in GriddedPSFModel; see #302
@@ -55,13 +56,14 @@ def test_compare_to_calc_psf_detsampled():
     """
     oversample = 2
     fov_arcsec = 0.5
+    nlambda = 1
 
     # Create PSF grid
     mir = webbpsf_core.MIRI()
     mir.filter = "F560W"
     mir.detector = "MIRIM"
     grid = mir.psf_grid(all_detectors=False, num_psfs=4, use_detsampled_psf=True, add_distortion=False,
-                        oversample=oversample, fov_arcsec=fov_arcsec)
+                        oversample=oversample, fov_arcsec=fov_arcsec, nlambda=nlambda)
 
     # Pull one of the PSFs out of the grid
     psfnum = 1
@@ -73,7 +75,7 @@ def test_compare_to_calc_psf_detsampled():
     # Using meta data, create the expected same PSF via calc_psf
     mir.detector_position = (locx, locy)
     mir.options['output_mode'] = 'Detector Sampled Image'
-    calcpsf = mir.calc_psf(oversample=oversample, fov_arcsec=fov_arcsec)["DET_SAMP"].data
+    calcpsf = mir.calc_psf(oversample=oversample, fov_arcsec=fov_arcsec, nlambda=nlambda)["DET_SAMP"].data
     kernel = astropy.convolution.Box2DKernel(width=1)
     convpsf = astropy.convolution.convolve(calcpsf, kernel)
 
@@ -234,10 +236,11 @@ def test_wfi():
     # Check add_distortion not specified defaults to false
     oversample = 2
     fov_pixels = 10
+    nlambda = 1
 
     # Create PSF grid
     wfi = roman.WFI()
-    grid = wfi.psf_grid(all_detectors=False, num_psfs=4, fov_pixels=fov_pixels, oversample=oversample)
+    grid = wfi.psf_grid(all_detectors=False, num_psfs=4, fov_pixels=fov_pixels, oversample=oversample, nlambda=nlambda)
 
     # Pull one of the PSFs out of the grid
     psfnum = 1
@@ -248,7 +251,7 @@ def test_wfi():
 
     # Using meta data, create the expected same PSF via calc_psf
     wfi.detector_position = (locx, locy)
-    calcpsf = wfi.calc_psf(oversample=oversample, fov_pixels=fov_pixels)["OVERSAMP"].data
+    calcpsf = wfi.calc_psf(oversample=oversample, fov_pixels=fov_pixels, nlambda=nlambda)["OVERSAMP"].data
     kernel = astropy.convolution.Box2DKernel(width=oversample)
     convpsf = astropy.convolution.convolve(calcpsf, kernel)
     scalefactor = oversample ** 2  # normalization as used internally in GriddedPSFModel; see #302

--- a/webbpsf/tests/test_psfgrid.py
+++ b/webbpsf/tests/test_psfgrid.py
@@ -193,7 +193,7 @@ def test_saving(tmpdir):
     fgs = webbpsf_core.FGS()
     fgs.filter = "FGS"
     fgs.detector = "FGS2"
-    grid = fgs.psf_grid(all_detectors=False, num_psfs=4, save=True, outdir=directory, outfile=file, overwrite=True)
+    grid = fgs.psf_grid(all_detectors=False, num_psfs=4, nlambda=1, save=True, outdir=directory, outfile=file, overwrite=True)
 
     # Check that the saved file matches the returned file (and thus that the save worked through properly)
     with fits.open(os.path.join(directory, file[:-5]+"_fgs2.fits")) as infile:

--- a/webbpsf/tests/test_roman.py
+++ b/webbpsf/tests/test_roman.py
@@ -20,7 +20,6 @@ def test_WFI_filters():
     wi = roman.WFI()
     filter_list = wi.filter_list
     for filter in filter_list:
-        wi = roman.WFI()
         wi.filter = filter
         wi.calc_psf(fov_pixels=4, oversample=1, nlambda=3)
 


### PR DESCRIPTION
Let's try to make the test suite not take 15+ minutes to run, without compromising coverage substantially. Are the tests we're running efficient? 

Method. Use `pytest --durations=0` to print out a list of the time consuming tests, then see if we can find efficiencies.

- use fewer wavelengths in psf_grid test to reduce test runtime, at no significant loss in test coverage. 
- Same for in test_opds for testing the 1024 vs 2048 npix, which does not require more than 1 wavelength. 


**Outputs from pytest durations prior to these changes**:
```
34.62s call     webbpsf/tests/test_psfgrid.py::test_wfi
26.75s call     webbpsf/tests/test_psfgrid.py::test_compare_to_calc_psf_detsampled
19.87s call     webbpsf/tests/test_psfgrid.py::test_saving
19.41s call     webbpsf/tests/test_roman.py::test_WFI_filters
16.83s call     webbpsf/tests/test_psfgrid.py::test_compare_to_calc_psf_oversampled
15.17s call     webbpsf/tests/test_fgs.py::test_fgs
14.31s call     webbpsf/tests/test_nircam.py::test_nircam_blc_wedge_45
14.07s call     webbpsf/tests/test_nircam.py::test_nircam_blc_wedge_0
13.60s call     webbpsf/tests/test_psfgrid.py::test_all_detectors
13.25s call     webbpsf/tests/test_nircam.py::test_nircam_blc_circ_45
12.79s call     webbpsf/tests/test_roman.py::test_WFI_fwhm
12.59s call     webbpsf/tests/test_nircam.py::test_nircam_blc_circ_0
12.09s call     webbpsf/tests/test_miri.py::test_miri
10.95s call     webbpsf/tests/test_nirspec.py::test_nirspec
10.86s call     webbpsf/tests/test_distortion.py::test_apply_distortion_skew
10.19s call     webbpsf/tests/test_nircam.py::test_nircam
```