### PR TITLE
Update CI

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -65,8 +65,14 @@ jobs:
     - name: Check conda info
       run: conda info
 
+    - name: Run tests with requirements file
+      if: ${{ contains(matrix.toxenv,'-latest') }}
+      run: |
+        cp $RUNNER_WORKSPACE/webbpsf/requirements.txt /tmp/
+        tox -e ${{ matrix.toxenv }}
+
     - name: Run tests
-      if: matrix.continue-on-error == null
+      if: ${{ matrix.continue-on-error == null && contains(matrix.toxenv,'-latest') != true }}
       run: tox -e ${{ matrix.toxenv }}
 
     - name: Run tests and allow failures

--- a/webbpsf/tests/test_distortion.py
+++ b/webbpsf/tests/test_distortion.py
@@ -36,6 +36,7 @@ def test_apply_distortion_skew():
 
     # Rebin data to get 3rd extension
     fgs.options["output_mode"] = "Both extensions"
+    fgs.options["detector_oversample"] = 1
     webbpsf_core.SpaceTelescopeInstrument._calc_psf_format_output(fgs, result=psf_siaf, options=fgs.options)
 
     # Test the slope of the rectangle
@@ -90,6 +91,7 @@ def test_apply_distortion_pixel_scale():
 
     # Rebin data to get 3rd extension
     fgs.options["output_mode"] = "Both extensions"
+    fgs.options["detector_oversample"] = 1
     webbpsf_core.SpaceTelescopeInstrument._calc_psf_format_output(fgs, result=psf_siaf, options=fgs.options)
 
     # Test that the change caused by the pixel distortion is approximately constant along the row
@@ -181,6 +183,7 @@ def test_apply_miri_scattering():
 
     # Rebin data to get 3rd extension
     mir.options["output_mode"] = "Both extensions"
+    mir.options["detector_oversample"] = 1
     webbpsf_core.SpaceTelescopeInstrument._calc_psf_format_output(mir, result=psf_cross, options=mir.options)
 
     # Test distortion function
@@ -267,6 +270,7 @@ def test_miri_conservation_energy():
 
     # Rebin data to get 3rd extension
     mir.options["output_mode"] = "Both extensions"
+    mir.options["detector_oversample"] = 1
     webbpsf_core.SpaceTelescopeInstrument._calc_psf_format_output(mir, result=psf_cross, options=mir.options)
 
     # Test distortion function


### PR DESCRIPTION
2 part PR to fix failing CI

1. Explicitly define the `detector_oversample` key in the `options` dictionary when building PSF objects by hand for these tests. This is now needed because of the poppy change here: https://github.com/spacetelescope/poppy/pull/453/

2. Update the CI yaml file to correctly pull the requirements file in our latest-dependencies test. (Before, it was failing because for some reason, the CI was now looking for the requirements.txt file in the tmp/ directory. So I fixed it by copying the file into the tmp/ directory first).