### PR TITLE
Use "==" instead of "is" for string comparisons

### DIFF
--- a/webbpsf/gridded_library.py
+++ b/webbpsf/gridded_library.py
@@ -329,7 +329,7 @@ class CreatePSFLibrary:
                 if self.instr in ["NIRCam", "NIRISS", "FGS"]:
                     meta["ROTATION"] = (psf[ext].header["ROTATION"], "PSF rotated to match detector rotation")
 
-                if self.instr is "MIRI":
+                if self.instr=="MIRI":
                     meta["MIR_DIST"] = (psf[ext].header["MIR_DIST"], "MIRI detector scattering applied")
                     meta["KERN_AMP"] = (psf[ext].header["KERN_AMP"],
                                         "Amplitude(A) in kernel function A * exp(-x / B)")

--- a/webbpsf/webbpsf_core.py
+++ b/webbpsf/webbpsf_core.py
@@ -230,7 +230,7 @@ class SpaceTelescopeInstrument(poppy.instrument.Instrument):
 
     @image_mask.setter
     def image_mask(self, name):
-        if name is "": name = None
+        if name=="": name = None
         if name is not None:
             if name in self.image_mask_list:
                 pass  # there's a perfect match, this is fine.
@@ -249,7 +249,7 @@ class SpaceTelescopeInstrument(poppy.instrument.Instrument):
 
     @pupil_mask.setter
     def pupil_mask(self, name):
-        if name is "":
+        if name=="":
             name = None
         if name is not None:
             if name in self.pupil_mask_list:
@@ -1833,7 +1833,7 @@ class NIRCam(JWInstrument):
     # Need to redefine image_mask.setter because _image_mask_apertures has limited aperture definitions
     @JWInstrument.image_mask.setter
     def image_mask(self, name):
-        if name is "": name = None
+        if name=="": name = None
         if name is not None:
             if name in self.image_mask_list:
                 pass  # there's a perfect match, this is fine.


### PR DESCRIPTION
Comparisons of some variables to strings were using `is` rather than `==`, likely due to changes from `None` to empty strings `""`.