### PR TITLE
Rename 'P750L LRS grating' -> 'P750L', per #477

### DIFF
--- a/docs/jwst.rst
+++ b/docs/jwst.rst
@@ -469,7 +469,7 @@ LRS Spectroscopy
 ----------------
 
 WebbPSF includes models for the LRS slit and the subsequent pupil stop on the
-grism in the wheels. Users should select ``miri.image_mask = "LRS slit"`` and ``miri.pupil_mask = 'P750L LRS grating'``.
+grism in the wheels. Users should select ``miri.image_mask = "LRS slit"`` and ``miri.pupil_mask = 'P750L'``.
 That said, the LRS simulations have not been extensively tested yet;
 feedback is appreciated about any issues encountered.
 

--- a/docs/more_examples.rst
+++ b/docs/more_examples.rst
@@ -183,7 +183,7 @@ MIRI LRS
 
     miri = webbpsf.MIRI()
     miri.image_mask = 'LRS slit'
-    miri.pupil_mask = 'P750L LRS grating'
+    miri.pupil_mask = 'P750L'
     psf = miri.calc_psf(monochromatic=6.0e-6, display=True)
 
 

--- a/docs/references.rst
+++ b/docs/references.rst
@@ -123,7 +123,7 @@ Lyot mask files:                                         Anthony Boccaletti priv
 
 LRS slit size (4.7 x 0.51 arcsec):     MIRI-TR-00001-CEA. And LRS Overview presentation by Silvia Scheithaur to MIRI team meeting May 2013.
 
-LRS P750L grating aperture mask (3.8% oversized tricontagon): MIRI OBA Design Description, MIRI-DD-00001-AEU
+LRS P750L prism aperture mask (3.8% oversized tricontagon): MIRI OBA Design Description, MIRI-DD-00001-AEU
 
 MIRI imager internal pupil stop in regular imaging mode: 4% oversized tricontagon, mounted on each of the imaging filters (with smoothed corners).
 

--- a/webbpsf/webbpsf_core.py
+++ b/webbpsf/webbpsf_core.py
@@ -1047,7 +1047,7 @@ class JWInstrument(SpaceTelescopeInstrument):
         # Add distortion if set in calc_psf
         if add_distortion:
             _log.debug("Adding PSF distortion(s)")
-            if self.image_mask == "LRS slit" and self.pupil_mask == "P750L LRS grating":
+            if self.image_mask == "LRS slit" and self.pupil_mask == "P750L":
                 raise NotImplementedError("Distortion is not implemented yet for MIRI LRS mode.")
 
             # Set up new extensions to add distortion to:
@@ -1347,7 +1347,7 @@ class MIRI(JWInstrument):
         self.options['pupil_shift_y'] = -0.0027
 
         self.image_mask_list = ['FQPM1065', 'FQPM1140', 'FQPM1550', 'LYOT2300', 'LRS slit']
-        self.pupil_mask_list = ['MASKFQPM', 'MASKLYOT', 'P750L LRS grating']
+        self.pupil_mask_list = ['MASKFQPM', 'MASKLYOT', 'P750L']
 
         self._image_mask_apertures = {'FQPM1065': 'MIRIM_CORON1065',
                                       'FQPM1140': 'MIRIM_CORON1140',
@@ -1502,7 +1502,7 @@ class MIRI(JWInstrument):
                              name=self.pupil_mask,
                              flip_y=True, shift_x=shift_x, shift_y=shift_y, rotation=rotation)
             optsys.planes[-1].wavefront_display_hint = 'intensity'
-        elif self.pupil_mask == 'P750L LRS grating' or self.pupil_mask == 'P750L':
+        elif self.pupil_mask == 'P750L':
             optsys.add_pupil(transmission=self._datapath + "/optics/MIRI_LRS_Pupil_Stop.fits.gz",
                              name=self.pupil_mask,
                              flip_y=True, shift_x=shift_x, shift_y=shift_y, rotation=rotation)


### PR DESCRIPTION
Fix #477, in which @skendrew pointed out that the MIRI LRS dispersing element is not a grating, so webbpsf shouldn't label it as such. 