### PR TITLE
add synphot as required dependency, and update some other min vers

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ photutils==1.2.0
 poppy>=0.9.1
 pysiaf==0.13.0
 scipy==1.7.3
-synphot==1.1.0
+synphot==1.1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ photutils==1.2.0
 poppy>=0.9.1
 pysiaf==0.13.0
 scipy==1.7.3
+synphot==1.1.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,13 +20,14 @@ max-line-length = 120
 zip_safe = False
 packages = find:
 install_requires =
-    numpy>=1.17.0
-    scipy>=1.4.0
-    matplotlib>=3.0.0
+    numpy>=1.18.0
+    scipy>=1.5.0
+    matplotlib>=3.2.0
     astropy>=4.0.0
-    photutils>=0.6.0
+    photutils>=1.0.0
     poppy>=0.9.1
-    pysiaf>=0.9.0
+    pysiaf>=0.11.0
+    synphot>=1.0.0
 python_requires = >=3.7
 setup_requires = setuptools_scm
 

--- a/tox.ini
+++ b/tox.ini
@@ -11,8 +11,8 @@ deps =
     pytest
     poppydev,legacy37,astropydev,latest: git+https://github.com/spacetelescope/poppy.git#egg=poppy
     pysiafdev,astropydev: git+https://github.com/spacetelescope/pysiaf.git#egg=pysiaf
-    legacy37: numpy==1.17.0
-    legacy37: pysiaf==0.9.0
+    legacy37: numpy==1.18.0
+    legacy37: pysiaf==0.11.0
     legacy37: astropy==4.0.0
     astropydev: git+git://github.com/astropy/astropy
     poppydev: synphot


### PR DESCRIPTION
Add `synphot` as a required dependency for WebbPSF. See discussion on https://github.com/spacetelescope/poppy/issues/464

Also, might as well update some of the minimum versions of dependencies to not-quite-as-old versions, in prep for 1.0. This is consistent with https://github.com/spacetelescope/poppy/pull/472