### PR TITLE
Add pytest-astropy-header to conftest.py

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,3 +3,8 @@ requires = ["setuptools >= 38.0.0",
             "setuptools_scm >= 2.0.0",
             "wheel"]
 build-backend = 'setuptools.build_meta'
+
+[tool.pytest.ini_options]
+testpaths = [
+    "webbpsf/tests",
+]

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,6 @@ setup_requires = setuptools_scm
 test =
     pytest
     pytest-astropy
-    pytest-astropy-header
 docs =
     nbsphinx
     stsci_rtd_theme

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,6 +35,7 @@ setup_requires = setuptools_scm
 test =
     pytest
     pytest-astropy
+    pytest-astropy-header
 docs =
     nbsphinx
     stsci_rtd_theme

--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,7 @@ envlist =
 passenv = *
 deps =
     pytest
+    pytest-astropy-header
     poppydev,legacy37,astropydev,latest: git+https://github.com/spacetelescope/poppy.git#egg=poppy
     pysiafdev,astropydev: git+https://github.com/spacetelescope/pysiaf.git#egg=pysiaf
     legacy37: numpy==1.18.0

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ envlist =
 passenv = *
 deps =
     pytest
-    pytest-astropy-header
+    pytest-astropy
     poppydev,legacy37,astropydev,latest: git+https://github.com/spacetelescope/poppy.git#egg=poppy
     pysiafdev,astropydev: git+https://github.com/spacetelescope/pysiaf.git#egg=pysiaf
     legacy37: numpy==1.18.0
@@ -20,7 +20,6 @@ deps =
     latest: -rrequirements.txt
     stable: poppy
     stable: pysiaf
-    cov: pytest-astropy
     cov: pytest-cov
     cov: codecov
     cov: coverage

--- a/webbpsf/conftest.py
+++ b/webbpsf/conftest.py
@@ -3,11 +3,22 @@
 # no matter how it is invoked within the source tree.
 
 try:
-    from astropy.tests.plugins.display import *
-    from astropy.tests.helper import *
-except ImportError:
-    from astropy.tests.pytest_plugins import *
+    from pytest_astropy_header.display import PYTEST_HEADER_MODULES, TESTED_VERSIONS
+except ImportError:  # In case this plugin is not installed
+    PYTEST_HEADER_MODULES = {}
+    TESTED_VERSIONS = {}
 
-## Uncomment the following line to treat all DeprecationWarnings as
-## exceptions
-# enable_deprecations_as_exceptions()
+# This really depends on how you set up your package version,
+# modify as needed.
+try:
+    from webbpsf import __version__ as version
+except ImportError:
+    version = ''
+
+def pytest_configure():
+    PYTEST_HEADER_MODULES.pop('Pandas', None)
+    PYTEST_HEADER_MODULES.pop('h5py', None)
+    PYTEST_HEADER_MODULES['Astropy'] = 'astropy'
+    PYTEST_HEADER_MODULES['Photutils'] = 'photutils'
+    PYTEST_HEADER_MODULES['Poppy'] = 'poppy'
+    TESTED_VERSIONS['Webbpsf'] = version


### PR DESCRIPTION
Update `conftest.py` to work with `astropy` > 5.0 - this requires calling `pytest-astropy-header`. This was causing the CI in the astropy development build to fail

I also added a setting in `pyproject.toml` to make sure that when `pytest` runs, it only searches the `tests/` directory for test files. This used to work on its own, but recently has been searching the wrong folders.  