### PR TITLE
Remove python 3.7 and add python 3.10 

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -13,33 +13,33 @@ jobs:
 
           - name: Coverage test in Python 3
             os: ubuntu-latest
-            python: 3.9
-            toxenv: py39-poppydev-pysiafdev-cov
+            python: '3.10'
+            toxenv: py310-poppydev-pysiafdev-cov
 
           - name: Check for Sphinx doc build errors
             os: ubuntu-latest
-            python: 3.8
+            python: 3.9
             toxenv: docbuild
 
           - name: Try Astropy development version
             os: ubuntu-latest
-            python: 3.8
-            toxenv: py38-astropydev-test
+            python: 3.9
+            toxenv: py39-astropydev-test
 
           - name: Try latest versions of all dependencies
             os: ubuntu-latest
-            python: 3.9
-            toxenv: py39-latest-test
+            python: '3.10'
+            toxenv: py310-latest-test
 
           - name: Try minimum supported versions
             os: ubuntu-latest
-            python: 3.7
-            toxenv: py37-legacy37-test
+            python: 3.8
+            toxenv: py38-legacy-test
 
           - name: Try released POPPY and PySIAF
             os: ubuntu-latest
-            python: 3.7
-            toxenv: py37-stable-test
+            python: 3.8
+            toxenv: py38-stable-test
             continue-on-error: 'true'
 
     steps:

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -5,22 +5,13 @@ on:
     types: [released]
 
 jobs:
-  build:
-      name: Publish release to PyPI
-      env:
-        PYPI_USERNAME_STSCI_MAINTAINER: ${{ secrets.PYPI_USERNAME_STSCI_MAINTAINER }}
-        PYPI_PASSWORD_STSCI_MAINTAINER: ${{ secrets.PYPI_PASSWORD_STSCI_MAINTAINER }}
-        PYPI_USERNAME_OVERRIDE: ${{ secrets.PYPI_USERNAME_OVERRIDE }}
-        PYPI_PASSWORD_OVERRIDE: ${{ secrets.PYPI_PASSWORD_OVERRIDE }}
-        PYPI_TEST: ${{ secrets.PYPI_TEST }}
-        INDEX_URL_OVERRIDE: ${{ secrets.INDEX_URL_OVERRIDE }}
-      runs-on: ubuntu-latest
-      steps:
-
-          # Check out the commit containing this workflow file.
-          - name: checkout repo
-            uses: actions/checkout@v2
-
-          - name: custom action
-            uses: spacetelescope/action-publish_to_pypi@master
-            id: custom_action_0
+jobs:
+  publish:
+    uses: spacetelescope/action-publish_to_pypi/.github/workflows/workflow.yml@master
+    with:
+      test: false
+      build_platform_wheels: false # Set to true if your package contains a C extension
+    secrets:
+      user: ${{ secrets.PYPI_USERNAME_STSCI_MAINTAINER }}
+      password: ${{ secrets.PYPI_PASSWORD_STSCI_MAINTAINER }} # WARNING: Do not hardcode secret values here! If you want to use a different user or password, you can override this secret by creating one with the same name in your Github repository settings.
+      test_password: ${{ secrets.PYPI_PASSWORD_STSCI_MAINTAINER_TEST }}

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -105,7 +105,7 @@ Software Requirements
 
 See `the environment.yml specification file <https://github.com/spacetelescope/webbpsf/blob/develop/requirements.txt>`_ for the required package dependencies.
 
-**Required Python version**: WebbPSF 1.0 and above require Python 3.8 or higher.
+**Required Python version**: WebbPSF 1.1 and above require Python 3.8 or higher.
 
 The major dependencies are the standard `NumPy, SciPy <http://www.scipy.org/scipylib/download.html>`_, `matplotlib <http://matplotlib.org>`_ stack, and `Astropy <http://astropy.org>`_
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -105,7 +105,7 @@ Software Requirements
 
 See `the environment.yml specification file <https://github.com/spacetelescope/webbpsf/blob/develop/requirements.txt>`_ for the required package dependencies.
 
-**Required Python version**: WebbPSF 1.0 and above require Python 3.7 or higher.
+**Required Python version**: WebbPSF 1.0 and above require Python 3.8 or higher.
 
 The major dependencies are the standard `NumPy, SciPy <http://www.scipy.org/scipylib/download.html>`_, `matplotlib <http://matplotlib.org>`_ stack, and `Astropy <http://astropy.org>`_
 

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -5,7 +5,7 @@ sphinx:
   configuration: docs/conf.py
 
 python:
-    version: 3.7
+    version: 3.9
     install:
         - method: pip
           path: .

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ install_requires =
     poppy>=1.0.0
     pysiaf>=0.11.0
     synphot>=1.0.0
-python_requires = >=3.7
+python_requires = >=3.8
 setup_requires = setuptools_scm
 
 [options.extras_require]

--- a/tox.ini
+++ b/tox.ini
@@ -1,20 +1,20 @@
 [tox]
 envlist =
-    py{37,38,39}-test
-    py{37,38,39}-{poppydev,pysiafdev,astropydev,latest,stable}-test
-    py37-legacy37-test
-    py{37,38,39}-{poppydev,pysiafdev}-cov
+    py{38,39,310}-test
+    py{38,39,310}-{poppydev,pysiafdev,astropydev,latest,stable}-test
+    py38-legacy-test
+    py{38,39,310}-{poppydev,pysiafdev}-cov
 
 [testenv]
 passenv = *
 deps =
     pytest
     pytest-astropy
-    poppydev,legacy37,astropydev,latest: git+https://github.com/spacetelescope/poppy.git#egg=poppy
+    poppydev,legacy,astropydev,latest: git+https://github.com/spacetelescope/poppy.git#egg=poppy
     pysiafdev,astropydev: git+https://github.com/spacetelescope/pysiaf.git#egg=pysiaf
-    legacy37: numpy==1.18.0
-    legacy37: pysiaf==0.11.0
-    legacy37: astropy==4.0.0
+    legacy: numpy==1.18.0
+    legacy: pysiaf==0.11.0
+    legacy: astropy==4.0.0
     astropydev: git+https://github.com/astropy/astropy
     poppydev: synphot
     latest: -rrequirements.txt
@@ -34,7 +34,7 @@ commands=
     cov: codecov -F -e TOXENV
 
 [testenv:docbuild]
-basepython= python3.8
+basepython= python3.9
 passenv= *
 deps=
     sphinx
@@ -52,7 +52,7 @@ commands=
     sphinx-build docs docs/_build
 
 [testenv:codestyle]
-basepython= python3.8
+basepython= python3.9
 skip_install = true
 description = check package code style
 deps =

--- a/webbpsf/__init__.py
+++ b/webbpsf/__init__.py
@@ -21,7 +21,7 @@ try:
 except ImportError:
     __version__ = ''
 
-__minimum_python_version__ = "3.7"
+__minimum_python_version__ = "3.8"
 
 
 class UnsupportedPythonError(Exception):


### PR DESCRIPTION
Remove support for Python 3.7, increase all CI tests by 1 Python version and now include Python 3.10

Also adding this here: updating the publish-to-pypi.yml file to work with new git security changes. This fix comes from  @zanecodes and was also implemented here https://github.com/spacetelescope/pysiaf/pull/240