### PR TITLE
minor: quiet a numpy deprecation warning

### DIFF
--- a/webbpsf/distortion.py
+++ b/webbpsf/distortion.py
@@ -237,8 +237,8 @@ def apply_distortion(hdulist_or_filename=None, fill_value=0):
     psf[ext].header["DISTORT"] = ("True", "SIAF distortion coefficients applied")
     psf[ext].header["SIAF_VER"] = (pysiaf.JWST_PRD_VERSION, "SIAF PRD version used")
 
-    degree = np.int(getattr(aper, 'Sci2IdlDeg'))
-    number_of_coefficients = np.int((degree + 1) * (degree + 2) / 2)
+    degree = int(getattr(aper, 'Sci2IdlDeg'))
+    number_of_coefficients = int((degree + 1) * (degree + 2) / 2)
     all_keys = aper.__dict__.keys()
     for axis in ['X', 'Y']:
         coeff_keys = np.sort(np.array([c for c in all_keys if 'Idl2Sci' + axis in c]))


### PR DESCRIPTION
originally part of #571 , but conceptually this had nothing to do with that, so split out to a separate branch during rebasing