### PR TITLE
enforce image origin = lower everywhere, for consistency

### DIFF
--- a/webbpsf/gridded_library.py
+++ b/webbpsf/gridded_library.py
@@ -526,7 +526,7 @@ def display_psf_grid(grid, zoom_in=True, figsize=(14, 12), scale_range=1e-4, dif
         for ix in range(n):
             for iy in range(n):
                 i = ix*n+iy
-                im = axes[n-1-iy, ix].imshow(data[i], norm=norm, cmap=cmap)
+                im = axes[n-1-iy, ix].imshow(data[i], norm=norm, cmap=cmap, origin='lower')
                 axes[n-1-iy, ix].xaxis.set_visible(False)
                 axes[n-1-iy, ix].yaxis.set_visible(False)
                 axes[n-1-iy, ix].set_title("{}".format(tuple_to_int(grid.grid_xypos[i])))

--- a/webbpsf/opds.py
+++ b/webbpsf/opds.py
@@ -285,7 +285,7 @@ class OPD(poppy.FITSOpticalElement):
         extent = [-max_cycles, max_cycles, -max_cycles, max_cycles]
 
         plt.subplot(233)
-        plt.imshow(abstrans, extent=extent)
+        plt.imshow(abstrans, extent=extent, origin='lower')
         plt.title("Power Spectrum of the phase")
         plt.ylabel("cycles/aperture")
         tvcircle(radius=5, color='k', linewidth=1)  # , ls='--')
@@ -317,7 +317,7 @@ class OPD(poppy.FITSOpticalElement):
             inverse = inverse[::-1, ::-1]  # I thought SFT did this but apparently this is necessary to get the high freqs right...
 
             plt.imshow(inverse.real * mask, vmin=(-vmax) / 1000., vmax=vmax / 1000,
-                       cmap=cmap)  # vmax is in nm, but WFE is in microns, so convert
+                       cmap=cmap, origin='lower')  # vmax is in nm, but WFE is in microns, so convert
             plt.title(label + " spatial frequencies")
             rms = (np.sqrt((inverse.real[wgood] ** 2).mean()) * 1000)
 
@@ -530,7 +530,7 @@ class OPD(poppy.FITSOpticalElement):
 
             # n, m = zernike.noll_indices(j)
             Z = zernike.zernike1(j, npix=npix)
-            ax.imshow(Z * zerns[j - 1] * hexap * scalefact, vmin=-1 * vmax, vmax=vmax, cmap=cmap)
+            ax.imshow(Z * zerns[j - 1] * hexap * scalefact, vmin=-1 * vmax, vmax=vmax, cmap=cmap, origin='lower')
             ax.text(npix * 0.95, npix * 0.8, "$Z{:d}$".format(j), fontsize=20, horizontalalignment='right')
             ax.text(npix * 0.95, npix * 0.1, "{:.2e}".format(zerns[j - 1]), fontsize=15, horizontalalignment='right')
 
@@ -840,10 +840,10 @@ class OTE_Linear_Model_Elliott(OPD):
 
         if debug:
             plt.subplot(121)
-            plt.imshow(Xr * (self._segment_masks == iseg))
+            plt.imshow(Xr * (self._segment_masks == iseg), origin='lower')
             plt.title("Local X_Control for " + segment)
             plt.subplot(122)
-            plt.imshow(Yr * (self._segment_masks == iseg))
+            plt.imshow(Yr * (self._segment_masks == iseg), origin='lower')
             plt.title("Local Y_Control for" + segment)
             plt.draw()
 
@@ -3367,7 +3367,7 @@ def get_coarse_blur_parameters(t0, duration, pixelscale, plot=False, case=1,):
 
 
         plt.figure()
-        plt.imshow(kernel, cmap = matplotlib.cm.gray)
+        plt.imshow(kernel, cmap = matplotlib.cm.gray, origin='lower')
         plt.title(f"Convolution kernel at t={t0}, d={duration} s\nOffset={cen} arcsec", fontsize=10)
         plt.ylabel('Delta V3 [pixels]')
 

--- a/webbpsf/optical_budget.py
+++ b/webbpsf/optical_budget.py
@@ -137,7 +137,7 @@ def show_opd(opd, mask = None, ax=None, vmax=200, title=None, annotate_budget=No
     cm.set_bad('0.75', alpha=0)
 
     ax.patch.set_facecolor('0.8')
-    ax.imshow(opd_nm, vmin=-vmax, vmax=vmax, cmap = cm)
+    ax.imshow(opd_nm, vmin=-vmax, vmax=vmax, cmap = cm, origin='lower')
     ax.xaxis.set_visible(False)
     ax.yaxis.set_visible(False)
     if title is not None:

--- a/webbpsf/trending.py
+++ b/webbpsf/trending.py
@@ -250,10 +250,10 @@ def show_opd_image(array, vmax=0.300, ax=None, title=None, colorbar=False, label
 
     if ax is None:
         plt.figure(figsize=(10, 8))
-        im = plt.imshow(array, cmap=matplotlib.cm.RdBu_r, vmin=-vmax, vmax=vmax, )
+        im = plt.imshow(array, cmap=matplotlib.cm.RdBu_r, vmin=-vmax, vmax=vmax, origin='lower')
         ax = im.axes
     else:
-        im = ax.imshow(array, cmap=matplotlib.cm.RdBu_r, vmin=-vmax, vmax=vmax, )
+        im = ax.imshow(array, cmap=matplotlib.cm.RdBu_r, vmin=-vmax, vmax=vmax, origin='lower')
 
     ax.set_facecolor('gray')
     ax.xaxis.set_visible(False)
@@ -862,7 +862,7 @@ def monthly_trending_plot(year, month, verbose=True, instrument='NIRCam', filter
     cmap.set_bad('0.4')
 
     def basic_show_image(image, ax, vmax=.3, nanmask=1):
-        ax.imshow(image * nanmask, cmap=cmap, vmin=-vmax, vmax=vmax)
+        ax.imshow(image * nanmask, cmap=cmap, vmin=-vmax, vmax=vmax, origin='lower')
         ax.xaxis.set_visible(False)
         ax.yaxis.set_visible(False)
         ax.set_yticks([])

--- a/webbpsf/webbpsf_core.py
+++ b/webbpsf/webbpsf_core.py
@@ -1370,7 +1370,7 @@ class JWInstrument(SpaceTelescopeInstrument):
 
         if plot:
             import matplotlib, matplotlib.pyplot as plt
-            plt.imshow(opd, vmin=-5e-7, vmax=5e-7, cmap=matplotlib.cm.RdBu_r)
+            plt.imshow(opd, vmin=-5e-7, vmax=5e-7, cmap=matplotlib.cm.RdBu_r, origin='lower')
             plt.title(kind+" WFE")
             mask = ote.get_transmission(wave) !=0
             plt.xlabel(f"RMS: {utils.rms(opd, mask)*1e9:.2f} nm")


### PR DESCRIPTION
from @obi-wan76 in #571:

> @mperrin I just noticed that the pupil orientation from my test is different than yours, I am not sure where are you setting the origin of the figure, webbpsf.trending.show_opd_image? Your example has the entrance pupil orientation so I am not sure if this is a change that already exist and will get merge as part of other PR. This is just a very minor detail, mostly for consistency.