### PR TITLE
Fixed typo in publish-to-pypi.yml

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -5,7 +5,6 @@ on:
     types: [released]
 
 jobs:
-jobs:
   publish:
     uses: spacetelescope/action-publish_to_pypi/.github/workflows/workflow.yml@master
     with:


### PR DESCRIPTION
The error resolved here may have prevented successful deployment of the new version of WebbPSF to PyPI. I would like to see the workflow pass before attempting the new release.