### PR TITLE
Adjusted install/release instructions post-conda

### DIFF
--- a/dev_utils/make-minimal-datafiles.py
+++ b/dev_utils/make-minimal-datafiles.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # Make minimal data files
-# This is used to make a stripped-down version of the data files for use on Travis CI
+# This is used to make a stripped-down version of the data files for use on GitHub Actions
 
 import os, sys
 import astropy.io.fits as fits

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -10,22 +10,23 @@ Requirements & Installation
    To subscribe, visit  the `maillist.stsci.edu server <https://maillist.stsci.edu/scripts/wa.exe?SUBED1=Webbpsf-users&A=1>`_
 
 
-.. _install-with-conda:
+.. NOTE: installation with conda is unavailable as of v1.1.0. uncomment and edit the following section once it's back.
+  .. _install_with_conda:
 
-Recommended: Installing with conda
-----------------------------------
+  Recommended: Installing with conda
+  ----------------------------------
 
-If you already use ``conda``, but do not want to install the full suite of STScI software, you can simply add the AstroConda *channel* and install WebbPSF as follows (creating a new environment named ``webbpsf-env``)::
+  If you already use ``conda``, but do not want to install the full suite of STScI software, you can simply add the AstroConda *channel* and install WebbPSF as follows (creating a new environment named ``webbpsf-env``)::
 
-   $ conda config --add channels http://ssb.stsci.edu/astroconda
-   $ conda create -n webbpsf-env webbpsf
-   $ conda activate webbpsf-env
+    $ conda config --add channels http://ssb.stsci.edu/astroconda
+    $ conda create -n webbpsf-env webbpsf
+    $ conda activate webbpsf-env
 
-Upgrading to the latest version is done with ``conda update -n webbpsf-env --all``.
+  Upgrading to the latest version is done with ``conda update -n webbpsf-env --all``.
 
-.. warning::
+  .. warning::
 
-   You *must* install WebbPSF into a specific environment (e.g. ``webbpsf-env``); our conda package will not work if installed into the default "root" environment.
+     You *must* install WebbPSF into a specific environment (e.g. ``webbpsf-env``); our conda package will not work if installed into the default "root" environment.
 
 .. _install_pip:
 
@@ -42,27 +43,10 @@ WebbPSF and its underlying optical library POPPY may be installed from the `Pyth
 Note that ``pip install webbpsf`` only installs the program code. **If you install via pip, you must manually download and install the data files, as** :ref:`described <data_install>` **below.**
 To obtain source spectra for calculations, you should also follow :ref:`installation instructions for synphot <synphot_install>`.
 
-
-Installing via AstroConda (legacy)
--------------------------------------
-
-.. warning::
-
-   While WebbPSF version 1.0.0 is installable via this method, **future WebbPSF releases will not be available through AstroConda.** We strongly recommend installing WebbPSF through plain conda or with pip instead.
-
-If you use `AstroConda <http://astroconda.readthedocs.io/en/latest/>`_, an astronomy-optimized software distribution for scientific Python built on Anaconda, activate the environment with::
-
-   $ conda activate astroconda
-
-(Note: if you named your environment something other than ``astroconda``, change the above command appropriately.)
-
-Next, install WebbPSF (along with all its dependencies and required reference data) with::
-
-   (astroconda)$ conda install webbpsf
-
-Updates to the latest version can be done as for any conda package::
-
-   (astroconda)$ conda update webbpsf
+.. note::
+  Installation through conda is not available as of WebbPSF version 1.1.0. Conda
+  users should instead follow the insructions in the preceding section to
+  install via pip.
 
 
 .. _synphot_install:
@@ -70,14 +54,18 @@ Updates to the latest version can be done as for any conda package::
 Installing or updating synphot
 --------------------------------
 
-Stsynphot is an optional dependency, but is highly recommended.  Stsynphot is best installed via AstroConda. Further installation instructions can be found in `the synphot docs <https://synphot.readthedocs.io/en/latest/#installation-and-setup>`_ or `a discussion in the POPPY docs <http://poppy-optics.readthedocs.io/en/stable/installation.html#installing-or-updating-synphot>`_.
+Stsynphot is an optional dependency, but is highly recommended. Its installation instructions can be found in `the synphot docs <https://synphot.readthedocs.io/en/latest/#installation-and-setup>`_ or `a discussion in the POPPY docs <http://poppy-optics.readthedocs.io/en/stable/installation.html#installing-or-updating-synphot>`_.
 
 .. _data_install:
 
 Installing the Required Data Files
 ----------------------------------
 
-*If you install via pip or manually*, you must install the data files yourself. If you install via Conda, the data files are automatically installed, in which case you can skip this section.
+*If you install via pip or manually*, you must install the data files yourself.
+
+.. (If you install via Conda, the data files are automatically installed, in
+    which case you can skip this section.) [uncomment once conda installation is
+    available again]
 
 Files containing such information as the JWST pupil shape, instrument throughputs, and aperture positions are distributed separately from WebbPSF. To run WebbPSF, you must download these files and tell WebbPSF where to find them using the ``WEBBPSF_PATH`` environment variable.
 

--- a/docs/release.rst
+++ b/docs/release.rst
@@ -66,9 +66,13 @@ When you are ready, proceed with the WebbPSF release as follows:
    #. Specify the version number, title, and brief description of the release.
    #. Press "Publish Release".
 
-#. Release to PyPI. This should now happen automatically on Travis. This will be triggered by a Travis build of a tagged commit on the `stable` branch, so it will happen automatically on the prior step for the PR into stable.
+#. Release to PyPI. This should now happen automatically on GitHub Actions. This will be triggered by a GitHub Actions build of a tagged commit on the `stable` branch, so it will happen automatically on the prior step for the PR into `stable`.
 
-#. Release to AstroConda, via steps below.
+.. note::
+
+  Once conda installation is working again, find this page in the documentation
+  for version 1.0.0 and adapt the steps from the "Releasing a new version
+  through AstroConda" section to the new process.
 
 Releasing a new version through AstroConda
 ==========================================

--- a/docs/relnotes.rst
+++ b/docs/relnotes.rst
@@ -30,11 +30,13 @@ Version History and Change Log
 
 Version 1.1.0
 =============
-*2022 September 20*
+*2022 September 21*
 
-*First release with JWST in flight optical performance!*  Updates and tools added after completion of commissioning. 
+*First release with JWST in flight optical performance!*  Updates and tools added after completion of commissioning.
 
 Note, this release requires updating your WebbPSF data files to version 1.1.0. See :ref:`here <data_install>` .
+
+This release's upgraded requirements drop support for Python 3.7, meaning conda installation is temporarily unavailable since the AstroConda channel is not equipped for newer Python versions. Installation with pip works as normal.
 
 **James Webb Space Telescope OTE model improvements**:
 


### PR DESCRIPTION
On conda, WebbPSF is only available through the AstroConda channel, which is only compatible with Python <=3.7. Since WebbPSF v1.1.0 will raise the Python requirement to 3.8, `conda install` can't work. I adjusted the installation and release documentation pages to reflect the change.