### PR TITLE
bug fix for include_ote_field_dependence setting

### DIFF
--- a/webbpsf/webbpsf_core.py
+++ b/webbpsf/webbpsf_core.py
@@ -920,7 +920,8 @@ class JWInstrument(SpaceTelescopeInstrument):
                 transmission=pupil_transmission,
                 opd=opd_map,
                 opd_index=opd_index,
-                v2v3=self._tel_coords(), npix=npix
+                v2v3=self._tel_coords(), npix=npix,
+                include_nominal_field_dependence=self.include_ote_field_dependence
             )
 
         return pupil_optic


### PR DESCRIPTION
The JWST instrument classes have an attribute `.include_ote_field_dependence` which is supposed to let you toggle off the OTE field dependence model. (Generally you don't want to do this but it can be useful in some contexts). That setting didn't actually work. This one-line fix makes it work. 


**example test code:**

```
for test_val in [True, False]:

    nrc.include_ote_field_dependence = test_val

    nrc.detector_position=(1024, 1024)
    opd1 = nrc.get_wfe('ote')

    nrc.detector_position=(0, 512)
    opd2 = nrc.get_wfe('ote')

    plt.figure()
    plt.imshow(opd1-opd2)
    plt.title(f"Delta OPD between 2 positions\nwith include field dep = {nrc.include_ote_field_dependence}",
             fontweight='bold')

    print(f"With OTE Field Dep={nrc.include_ote_field_dependence}, do OPDs vary with position? "
          f"{not np.allclose(opd1, opd2)}")
```

**without this fix, regardless of the setting, the OPD still changes with detector position:**

<img width="715" alt="Screen Shot 2022-10-08 at 5 37 19 PM" src="https://user-images.githubusercontent.com/1151745/194728674-4e21f3ad-425f-4a8f-837b-129e93efbc85.png">

**With this fix, the setting lets you turn off the field dependence:**

<img width="873" alt="Screen Shot 2022-10-08 at 5 37 52 PM" src="https://user-images.githubusercontent.com/1151745/194728705-da3f2f92-4fc1-4360-bff5-9add6f9e769e.png">

