### PR TITLE
update was target phase map filename. Fixes #609

### DIFF
--- a/webbpsf/trending.py
+++ b/webbpsf/trending.py
@@ -358,7 +358,7 @@ def single_measurement_trending_plot(opdtable, row_index=-1, verbose=True, vmax=
             print("     Subtracting NIRCam SI WFE target phase map")
 
         # Get WSS Target Phase Map
-        was_targ_file = os.path.join(webbpsf.utils.get_webbpsf_data_path(), 'NIRCam', 'OPD', 'wss_target_phase.fits')
+        was_targ_file = os.path.join(webbpsf.utils.get_webbpsf_data_path(), 'NIRCam', 'OPD', 'wss_target_phase_fp1.fits')
         target_1024 = astropy.io.fits.getdata(was_targ_file)
         target_256 = poppy.utils.krebin(target_1024, (256, 256)) /16   # scale factor for rebinning w/out increasing values
 
@@ -652,7 +652,7 @@ def wavefront_drift_plots(opdtable, start_time, end_time, verbose=False,
     mask = opd != 0
 
     # Get WSS Target Phase Map
-    was_targ_file = os.path.join(webbpsf.utils.get_webbpsf_data_path(), 'NIRCam', 'OPD', 'wss_target_phase.fits')
+    was_targ_file = os.path.join(webbpsf.utils.get_webbpsf_data_path(), 'NIRCam', 'OPD', 'wss_target_phase_fp1.fits')
     target_1024 = astropy.io.fits.getdata(was_targ_file)
     target_256 = poppy.utils.krebin(target_1024, (256, 256))
 

--- a/webbpsf/webbpsf_core.py
+++ b/webbpsf/webbpsf_core.py
@@ -1487,7 +1487,7 @@ class JWInstrument(SpaceTelescopeInstrument):
             sensing_inst.set_position_from_aperture_name(sensing_apername)
             # special case: for the main sensing point FP1, we use the official WAS target phase map, rather than the
             # WebbPSF-internal SI WFE model.
-            was_targ_file = os.path.join(utils.get_webbpsf_data_path(), 'NIRCam', 'OPD', 'wss_target_phase.fits')
+            was_targ_file = os.path.join(utils.get_webbpsf_data_path(), 'NIRCam', 'OPD', 'wss_target_phase_fp1.fits')
             if sensing_apername == 'NRCA3_FP1' and os.path.exists(was_targ_file):
                 sensing_fp_si_wfe = poppy.FITSOpticalElement(opd=was_targ_file).opd
             else:


### PR DESCRIPTION
Fixes #609 by updating all references to the WSS target phase map file to be 'wss_target_phase_fp1.fits'. Note the contents of this file in the distribution still need to be fixed as well. 