### PR TITLE
remove usages of deprecated `codecov` package

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -21,7 +21,6 @@ deps =
     stable: poppy
     stable: pysiaf
     cov: pytest-cov
-    cov: codecov
     cov: coverage
 conda deps =
     scipy
@@ -32,7 +31,6 @@ conda deps =
 commands=
     test: pytest {posargs}
     cov: pytest {posargs} --cov-config=pyproject.toml --cov-report=xml --cov=webbpsf webbpsf/tests/
-    cov: codecov -F -e TOXENV
 
 [testenv:docbuild]
 basepython= python3.9


### PR DESCRIPTION
the `codecov` package is deprecated; Codecov upload is taken care of by the CI action