### PR TITLE
Tune detector effects model parameters to better match measured ePSFs

### DIFF
--- a/webbpsf/constants.py
+++ b/webbpsf/constants.py
@@ -250,9 +250,9 @@ JWST_TYPICAL_LOS_JITTER_PER_AXIS = 0.0008 # milliarcseconds jitter, 1 sigma per 
 # Note, these are parameterized as arcseconds for convenience (and consistency with the jitter paramater)
 # but the underlying physics cares more about detector pixel pitch.
 INSTRUMENT_DETECTOR_CHARGE_DIFFUSION_DEFAULT_PARAMETERS = {
-    'NIRCAM_SW': 0.006,     # Fit by Marcio to WFS TA ePSFs
-    'NIRCAM_LW': 0.012,     # Scaled up by pixel pitch
-    'NIRISS': 0.028,         # Fit by Marcio to MIMF-3 F158M (ePSF)
+    'NIRCAM_SW': 0.0062,    # Fit by Marcio to WFS TA ePSFs, and by Marshall to prelim NIRCam SW ePSFs by J. Anderson
+    'NIRCAM_LW': 0.018,     # Fit by Marshall to prelim LW ePSFs by J. Anderson
+    'NIRISS': 0.0202,       # Fit by Marcio to MIMF-3 F158M (ePSF), and by Marshall to NIRISS ePSFs by Anderson & Libralato
     'FGS': 0.07,            # Fit by Marcio to FGS_ID images
     'NIRSPEC': 0.036,
     'MIRI': 0.001,          # Fit by Marshall + Marcio to ePSFs, after adding IPC

--- a/webbpsf/constants.py
+++ b/webbpsf/constants.py
@@ -255,8 +255,8 @@ INSTRUMENT_DETECTOR_CHARGE_DIFFUSION_DEFAULT_PARAMETERS = {
     'NIRISS': 0.028,         # Fit by Marcio to MIMF-3 F158M (ePSF)
     'FGS': 0.07,            # Fit by Marcio to FGS_ID images
     'NIRSPEC': 0.036,
-    'MIRI': 0.05,          # Fit by Marcio to F560W ePSF and single PSF (MIMF-3)
-                           #  0.070 Based on user reports, see issue #674. However, this is before adding IPC effects
+    'MIRI': 0.001,          # Fit by Marshall + Marcio to ePSFs, after adding IPC
+                            #  0.070 Based on user reports, see issue #674. However, this was before adding IPC effects
 }
 # add Interpixel capacitance (IPC) effects. These are the parameters for each detector kernel
 # For NIRCam we  use CV3/Flight convolution kernels from Jarron Leisenring, see detectors.apply_detector_ipc for details
@@ -264,3 +264,8 @@ INSTRUMENT_DETECTOR_CHARGE_DIFFUSION_DEFAULT_PARAMETERS = {
 INSTRUMENT_IPC_DEFAULT_KERNEL_PARAMETERS = {
     'MIRI': (0.033, 0.024, 0.013),          # Based on JWST-STScI-002925 by Mike Engesser
 }
+
+# How many detector pixels to mask out for the inner "hole" in the cruciform?
+# See Gaspar et al. 2021 for illustrative figures.
+# This is a rough approximation of a detector-position-dependent phenomenon
+MIRI_CRUCIFORM_INNER_RADIUS_PIX = 12


### PR DESCRIPTION
Adjust various free parameters to better tune simulated ePSFs to match measured ePSFs. 

**MIRI:** 
- Add new parameter `psf_location_list` to psf grid creation, which can be used to specify custom locations for the PSFs in a grid. This is needed to match Mattia's ePSFs for MIRI which have the X samples at [0, 352, 1032]. 
- Reduce charge diffusion sigma to 0.001 (essentially zero), because the IPC effect alone appears to dominate for this.
- Reduce cruciform intensity by 0.5. For the innermost region,  within the inner 12 detector pixels, further reduce it down to 0.25.  

**NIRCam:**
- For SW, adjust charge_diffusion_sigma from 0.006 to 0.0062. This provides a better fit to the ensemble of measured ePSFs across all 8 SW detectors (at a cost of slightly less good fit to NRCA3 in particular)
- For LW, adjust charge_diffusion_sigma from 0.012 to 0.018. This provides a much better fit to the ensemble of measured ePSFs across both LW detectors, versus the prior value which was a hand wave I made up without testing. 

**NIRISS:**
 - Adjust charge_diffusion_sigma from 0.018 to 0.021. This provides a better fit to the full ensemble of measured ePSFs for NIRISS, though it does so by improving the longer wavelength filters but making the shorter wavelength filters fit less well. 
 -  This is debatable and we should think about it more maybe; this seems like the best current motivation for complicating this by adding a wavelength dependence... The SW filters would be better fit by using 0.020, the LW filters by 0.021, so maybe split the difference and set the default to 0.0205? Or add in a wavelength dependence.
 
 


Figures for MIRI, NIRCam, NIRISS follow. 

![epsf_comparison_miri_0 001](https://github.com/spacetelescope/webbpsf/assets/1151745/159bc9eb-f9f7-4fe4-bf8b-ad991f4aaa8b)

![epsf_comparison_nircam_0 0062_0 017](https://github.com/spacetelescope/webbpsf/assets/1151745/9073dd7c-d912-440d-b378-34166ca8d48b)

![epsf_comparison_niriss_0 0202](https://github.com/spacetelescope/webbpsf/assets/1151745/2ec99f02-bd29-4515-b9ec-971f74f114b1)
