### PR TITLE
Increment minimum data files version to 1.2.0

### DIFF
--- a/webbpsf/__init__.py
+++ b/webbpsf/__init__.py
@@ -40,7 +40,7 @@ if sys.version_info < tuple(
 # required. If changes to the code and data mean WebbPSF won't work
 # properly with an old data package, increment this version number.
 # (It's checked against $WEBBPSF_DATA/version.txt)
-DATA_VERSION_MIN = (1, 1, 1)
+DATA_VERSION_MIN = (1, 2, 0)
 
 
 class Conf(_config.ConfigNamespace):


### PR DESCRIPTION
Partially addresses #692, by making webbpsf give an error if you don't have the new data files yet... Another PR will be needed to update the docs download URLs etc 