### PR TITLE
Update import path for GriddedPSFModel

### DIFF
--- a/webbpsf/gridded_library.py
+++ b/webbpsf/gridded_library.py
@@ -112,9 +112,12 @@ class CreatePSFLibrary:
 
         # Before doing anything else, check that we have GriddedPSFModel
         try:
-            from photutils import GriddedPSFModel
+            from photutils.psf import GriddedPSFModel
         except ImportError:
-            raise ImportError("This method requires photutils >= 0.6")
+            try:
+                from photutils import GriddedPSFModel
+            except ImportError:
+                raise ImportError("This method requires photutils >= 0.6")
 
         # Pull WebbPSF instance
         self.webb = instrument


### PR DESCRIPTION
Importing `GriddedPSFModel` directly from `photutils` without specifying the `psf` module has been deprecated since https://github.com/astropy/photutils/pull/1433, which causes WebbPSF calls to warn:
```
webbpsf/gridded_library.py:108: DeprecationWarning: `photutils.GriddedPSFModel` is a 
deprecated alias for `photutils.psf.GriddedPSFModel` and will be removed in the future.
Instead, please use `from photutils.psf import GriddedPSFModel` to silence this warning.
```
This PR first tries to import `GriddedPSFModel` from the `psf` module, and falls back on old the top-level import if that fails. Failing both of these, the `ImportError` is raised.