### PR TITLE
Update deprecated scipy namespace

### DIFF
--- a/webbpsf/distortion.py
+++ b/webbpsf/distortion.py
@@ -4,7 +4,7 @@ import astropy.io.fits as fits
 import numpy as np
 import pysiaf
 from scipy.interpolate import RegularGridInterpolator
-from scipy.ndimage.interpolation import rotate
+from scipy.ndimage import rotate
 
 def _get_default_siaf(instrument, aper_name):
     """


### PR DESCRIPTION
Similar to #696, this PR updates the namespace for `scipy.ndimage.rotate`, which is currently raising the following warning:
```
webbpsf/distortion.py:8: DeprecationWarning: Please use `rotate` from the `scipy.ndimage` 
namespace, the `scipy.ndimage.interpolation` namespace is deprecated.
```