### PR TITLE
add setup_sim_to_match_data function

### DIFF
--- a/webbpsf/__init__.py
+++ b/webbpsf/__init__.py
@@ -127,3 +127,5 @@ from .opds import enable_adjustable_ote
 from .roman import WFI, RomanCoronagraph
 
 from .jupyter_gui import show_notebook_interface
+
+from .match_data import setup_sim_to_match_file

--- a/webbpsf/match_data.py
+++ b/webbpsf/match_data.py
@@ -1,0 +1,68 @@
+## Functions to match or fit PSFs to observed JWST data
+import astropy
+import astropy.units as u
+import astropy.io.fits as fits
+
+import scipy.optimize
+
+import webbpsf
+
+
+def setup_sim_to_match_file(filename_or_HDUList, verbose=True, plot=False):
+    """ Setup a webbpsf Instrument instance matched to a given 
+    """
+    if isinstance(filename_or_HDUList,str):
+        if verbose:
+            print(f"Setting up sim to match {filename_or_HDUList}")
+        header = fits.getheader(filename_or_HDUList)
+    else:
+        header = filename_or_HDUList[0].header
+        if verbose:
+            print(f"Setting up sim to match provided FITS HDUList object")
+
+    inst = webbpsf.instrument(header['INSTRUME'])
+
+    if inst.name=='MIRI' and header['FILTER']=='P750L':
+        # webbpsf doesn't model the MIRI LRS prism spectral response
+        print("Please note, webbpsf does not currently model the LRS spectral response. Setting filter to F770W instead.")
+        inst.filter='F770W'
+    else:
+        inst.filter=header['filter']
+    inst.set_position_from_aperture_name(header['APERNAME'])
+
+    dateobs = astropy.time.Time(header['DATE-OBS']+"T"+header['TIME-OBS'])
+    inst.load_wss_opd_by_date(dateobs, verbose=verbose, plot=plot)
+
+
+    # per-instrument specializations
+    if inst.name == 'NIRCam':
+        if header['PUPIL'].startswith('MASK'):
+            inst.pupil_mask = header['PUPIL']
+            inst.image_mask = header['CORONMSK'].replace('MASKA', 'MASK')  # note, have to modify the value slightly for
+                                                                           # consistency with the labels used in webbpsf
+    elif inst.name == 'MIRI':
+        if inst.filter in ['F1065C', 'F1140C', 'F1550C']:
+            inst.image_mask = 'FQPM'+inst.filter[1:5]
+        elif inst.filter == 'F2300C':
+            inst.image_mask = 'LYOT2300'
+        elif header['FILTER'] == 'P750L':
+            inst.pupil_mask = 'P750L'
+            if header['APERNAME'] == 'MIRIM_SLIT':
+                inst.image_mask = 'LRS slit'
+
+    # TODO add other per-instrument keyword checks
+
+    if verbose:
+        print(f"""
+Configured simulation instrument for:
+    Instrument: {inst.name}
+    Filter: {inst.filter}
+    Detector: {inst.detector}
+    Apername: {inst.aperturename}
+    Det. Pos.: {inst.detector_position} {'in subarray' if "FULL" not in inst.aperturename else ""}
+    Image plane mask: {inst.image_mask}
+    Pupil plane mask: {inst.pupil_mask}
+    """)
+
+    return inst
+


### PR DESCRIPTION
Another simple PR adding a single-purpose utility function that I wrote a while ago.

The function `setup_sim_to_match_data` takes the filename of some observed JWST data, and sets up a simulated instrument instance to match it. The match includes choice of instrument, detector and detector position based on APERNAME, filter, any image or pupil masks relevant, and the closest available WFS. 

This is all straightforward, it just provides convenience to have a function that automates this setup. 

Example usage:

<img width="940" alt="example_output_setup_sim" src="https://github.com/spacetelescope/webbpsf/assets/1151745/7cde3dda-c481-4dc0-a5c2-378af5d2811f">

