### PR TITLE
add missing jquery extension to fix docs search

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -75,6 +75,7 @@ extensions = [
     "sphinx.ext.inheritance_diagram",
     "sphinx.ext.viewcode",
     "sphinx.ext.autosummary",
+    "sphinxcontrib.jquery",
     "sphinx_automodapi.automodapi",
     "sphinx_issues",
     "nbsphinx",


### PR DESCRIPTION
Search in the docs (on readthedocs) is currently failing due to missing jquery. This impacted a number of similar packages (see this PR fixing JWST docs: https://github.com/spacetelescope/jwst/pull/7524/files).

This PR applies the same fix as in the above linked PR, adding `sphinxcontrib.jquery` to the sphinx extensions to hopefully fix search in the documentation.