### PR TITLE
numpy 2.0 fixes

### DIFF
--- a/webbpsf/gridded_library.py
+++ b/webbpsf/gridded_library.py
@@ -340,7 +340,7 @@ class CreatePSFLibrary:
                 if self.fov_pixels % 2 == 0:
                     loc += 0.5  # even arrays must be at a half pixel
 
-                meta["DET_YX{}".format(h)] = (str((loc[1], loc[0])),
+                meta["DET_YX{}".format(h)] = (str((float(loc[1]), float(loc[0]))),
                                               "The #{} PSF's (y,x) detector pixel position".format(h))
 
             meta["NUM_PSFS"] = (self.num_psfs, "The total number of fiducial PSFs")

--- a/webbpsf/optics.py
+++ b/webbpsf/optics.py
@@ -836,7 +836,7 @@ class NIRCam_BandLimitedCoron(poppy.BandLimitedCoron):
             else:
                 raise NotImplementedError("invalid name for NIRCam wedge occulter")
 
-            sigmas = scipy.poly1d(polyfitcoeffs)(scalefact)
+            sigmas = np.poly1d(polyfitcoeffs)(scalefact)
 
             sigmar = sigmas * np.abs(y)
             # clip sigma: The minimum is to avoid divide by zero
@@ -1022,7 +1022,7 @@ def _calc_blc_wedge(deg=4, wavelength=2.1e-6):
     sigs = [_width_blc(difflim * ri) for ri in r]
 
     pcs = scipy.polyfit(r, sigs, deg)
-    p = scipy.poly1d(pcs)
+    p = np.poly1d(pcs)
     plt.plot(r, sigs, 'b')
     plt.plot(r, p(r), "r--")
     diffs = (sigs - p(r))

--- a/webbpsf/utils.py
+++ b/webbpsf/utils.py
@@ -263,9 +263,9 @@ wxpython version: {wxpython}
 
 
 ***************************************************************
-Floating point type information for numpy.float_:
+Floating point type information for numpy.double:
 {finfo_float}
-Floating point type information for numpy.complex:
+Floating point type information for numpy.cdouble:
 {finfo_complex}
 
 ***************************************************************
@@ -418,8 +418,8 @@ def system_diagnostic():
         stsyn=stsynphot_version,
         pysyn=pysynphot_version,
         astropy=astropy_version,
-        finfo_float=numpy.finfo(numpy.float_),
-        finfo_complex=numpy.finfo(numpy.complex_),
+        finfo_float=numpy.finfo(numpy.double),
+        finfo_complex=numpy.finfo(numpy.cdouble),
         numexpr=numexpr_version,
         scipy=scipy.__version__,
         accelerate=accelerate_version,


### PR DESCRIPTION
The changes in this PR partially address: https://github.com/spacetelescope/webbpsf/issues/737

numpy 2.0 changes the string format of scalars this format was relied on in gridded_library which this PR updates to first convert the values to builtin floats prior to converting to strings.

numpy 2.0 also removes `float_` and `complex_`. This PR replaces their usage with `double` and `cdouble`. See: https://github.com/numpy/numpy/pull/24376 for the numpy changes and the docs for a description of how `float_` is an alias of `double` and `complex_` an alias of `cdouble`: https://numpy.org/doc/stable/reference/arrays.scalars.html#numpy.float_

I attempted to update the CI to use numpy 2.0 and failed. I ran into many issues with versions conflicts that could be boiled down to `contourpy` (used by `matplotlib`) setting an upper pin on numpy 2.0. I was able to get things working locally (although this required building scipy from source as the nightly builds for m1 macs are very out-of-date). With the changes in this PR all tests pass except for 3:
```
FAILED webbpsf/tests/test_nircam.py::test_nircam_blc_wedge_0 - AttributeError: Module 'scipy' has no attribute 'poly1d'
FAILED webbpsf/tests/test_nircam.py::test_nircam_blc_wedge_45 - AttributeError: Module 'scipy' has no attribute 'poly1d'
FAILED webbpsf/tests/test_webbpsf.py::test_return_intermediates - AttributeError: Module 'scipy' has no attribute 'poly1d'
```
These are due to `poly1d` usage in `poppy` addressed here: https://github.com/spacetelescope/poppy/pull/585