### PR TITLE
import GriddedPSFModel from photutils.psf

### DIFF
--- a/webbpsf/gridded_library.py
+++ b/webbpsf/gridded_library.py
@@ -427,9 +427,12 @@ class CreatePSFLibrary:
             and oversampling keys
         """
         try:
-            from photutils import GriddedPSFModel
+            from photutils.psf import GriddedPSFModel
         except ImportError:
-            raise ImportError("This method requires photutils >= 0.6")
+            try:
+                from photutils import GriddedPSFModel
+            except ImportError:
+                raise ImportError("This method requires photutils >= 0.6")
 
         ndd = NDData(data, meta=meta, copy=True)
 

--- a/webbpsf/utils.py
+++ b/webbpsf/utils.py
@@ -834,9 +834,12 @@ def to_griddedpsfmodel(HDUlist_or_filename=None, ext_data=0, ext_header=0):
         grid_xypos and oversampling keys
     """
     try:
-        from photutils import GriddedPSFModel
+        from photutils.psf import GriddedPSFModel
     except ImportError:
-        raise ImportError("This method requires photutils >= 0.6")
+        try:
+            from photutils import GriddedPSFModel
+        except ImportError:
+            raise ImportError("This method requires photutils >= 0.6")
 
     if isinstance(HDUlist_or_filename, str):
         HDUlist = fits.open(HDUlist_or_filename)


### PR DESCRIPTION
This PR updates the remaining `GriddedPSFModel` imports from `photutils` to prefer importing from the `psf` submodule to avoid deprecation warnings issued when importing from the top level `photutils` module.

The modifications here are equivalent to the existing `try/except` found in `gridded_library.py`:
https://github.com/spacetelescope/webbpsf/blob/be742288089484d1ac94096d0bce33d5d2adb2be/webbpsf/gridded_library.py#L113-L120
