### PR TITLE
Update trending plot to subtract piston before displaying proposed correction

### DIFF
--- a/webbpsf/trending.py
+++ b/webbpsf/trending.py
@@ -661,6 +661,10 @@ def single_measurement_trending_plot(opdtable, row_index=-1, reference=None, ver
     iax = axes[2, 2]
 
     if show_correction:
+        # Note, the WSS does not remove piston from the correction so it's not zero mean.
+        # Fix that here before display. This also affects the derived rms value displayed.
+        correction -= np.nanmean(correction[correction_mask==1])
+
         show_opd_image(-correction, ax=iax, vmax=vmax, mask=correction_mask, fontsize=fontsize)
         iax.set_title(f"Controllable modes\nfrom WSS proposed correction", fontsize=fontsize*1.1)
 


### PR DESCRIPTION
The WSS doesn't subtract piston from the proposed correction that it writes out in the OPD files. (The MCS does subsequently remove global piston before generating SURs). 

This PR changes the display code in single_measurement_trending_plot so it subtracts the piston before displaying the proposed correction. This also affects the computed RMS WFE values, removing a bias that was making those appear higher. (related to the subtle distinction between the RMS and the std dev, which the WSS code handles differently in various cases). 

Before and after plots. Only change is in the marked panel in the bottom row: 

**Before (with current code):**

![Unknown](https://github.com/spacetelescope/webbpsf/assets/1151745/1968f25f-8098-42c5-b84b-4cae98055723)


**After this PR (with proposed modified code)**

![Unknown-1](https://github.com/spacetelescope/webbpsf/assets/1151745/e0f7476f-e0a4-45af-9aca-46ae77f74ee4)
