### PR TITLE
Add pytest plugin to mark tests as requiring the "remote" webbpsf related data

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,9 @@ docs = [
 Homepage = "http://webbpsf.readthedocs.io/"
 github_project = "https://github.com/spacetelescope/webbpsf"
 
+[project.entry-points]
+pytest11 = {webbpsf = 'pytest_plugin.plugin'}
+
 [tool.setuptools.packages]
 find = {namespaces = false}
 

--- a/webbpsf/pytest_plugin/plugin.py
+++ b/webbpsf/pytest_plugin/plugin.py
@@ -1,0 +1,23 @@
+import pytest
+
+
+def pytest_configure(config):
+    config.addinivalue_line(
+        "markers", "webbpsf: mark test as requiring webbpsf data to run"
+    )
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--webbpsf", action="store_true", default=False, help="run webbpsf tests"
+    )
+
+
+def pytest_collection_modifyitems(config, items):
+    if config.getoption("--webbpsf"):
+        # --runslow given in cli: do not skip slow tests
+        return
+    skip_webbpsf = pytest.mark.skip(reason="need --webbpsf option to run")
+    for item in items:
+        if "webbpsf" in item.keywords:
+            item.add_marker(skip_webbpsf)


### PR DESCRIPTION
Some uses of WebbPSF require the use of specific external data. This means that if users want to test their code which uses WebbPSF they must get this data. This makes general testing of those downstream pacakges quite complex.

This PR adds a `pytest` plugin to WebbPSF so that a special marker can be defined `pytest.mark.webbpsf` to mark those tests. This marker turns those tests off by default so that users can easily test parts of their code unrelated to WebbPSF, while providing them with the flag `--webpsf` to enable these tests.