### PR TITLE
update NRC coron dispersion coeffs

### DIFF
--- a/webbpsf/optics.py
+++ b/webbpsf/optics.py
@@ -1503,13 +1503,23 @@ class NIRCamFieldAndWavelengthDependentAberration(WebbFieldDependentAberration):
         self.fm_long  = np.poly1d(lw_focus_cf)
 
         # Coronagraphic tilt (`ctilt`) offset model
-        # Primarily effects the LW channel (approximately a 0.031mm diff from 3.5um to 5.0um).
-        # SW module is small compared to LW, but we include it for completeness.
-        # Values have been determined using the Zernike offsets as reported in the 
-        # NIRCam Zemax models. The center reference positions will correspond to the 
-        # NIRCam target acquisition filters (3.35um for LW and 2.1um for SW)
-        sw_ctilt_cf = np.array([125.849834, -289.018704]) / 1e9
-        lw_ctilt_cf = np.array([146.827501, -2000.965222, 8385.546158, -11101.658322]) / 1e9
+        # Due to dispersion in the wedge elements, the location of the coronagraphic
+        # image on the detectors is wavelength dependent. The relative shift of the COM
+        # features at the image plane in raw pixels:
+        # LWA (relative to 3.5um)
+        #    2.5,   3.0,  3.5,   4.0,   4.5 umhttps://www.google.com/search?client=safari&rls=en&q=16&ie=UTF-8&oe=UTF-8
+        #  -1.43, -0.32, 0.00, -0.15, -0.60 (ypix)
+        # SWA (relative to 2.0um)
+        #    0.5,   1.0,  1.5,   2.0,   2.5 um
+        #  30.51,  8.15, 3.29,  0.00, -3.31 (ypix)
+        # Note: This does not affect the mapping of the COM to the sky, but the COM and sky
+        # will both shift on the detector due to the dispersion.
+        # The final center reference positions will correspond to the NIRCam target acquisition 
+        # filter wavelengths (3.35um for LW and 2.1um for SW).
+        # For SW filters, we only care about wavelength between 1.7 and 2.3um, which has a linear offset.
+        sw_ctilt_cf = np.array([-1620.3792, +3240.7584]) / 1e9
+        # LW dispersion is a little more complicated, so we use a 3rd order polynomial
+        lw_ctilt_cf = np.array([-134.9596, +1939.0256, -8683.2786, +12515.1242]) / 1e9
         self.ctilt_short = np.poly1d(sw_ctilt_cf)
         self.ctilt_long  = np.poly1d(lw_ctilt_cf)
 
@@ -1591,7 +1601,7 @@ class NIRCamFieldAndWavelengthDependentAberration(WebbFieldDependentAberration):
 
             tilt_offset = ctilt_model(wave_um) - ctilt_model(ta_ref_wave)
             _log.info("  Applying OPD tilt adjustment based on NIRCam tilt vs wavelength model")
-            _log.info("  Modified tilt from {} to {} um: {:.3f} nm wfe".format(
+            print("  Modified tilt from {} to {} um: {:.3f} nm wfe".format(
                 ta_ref_wave, wave_um, tilt_offset * 1e9)
             )
 

--- a/webbpsf/optics.py
+++ b/webbpsf/optics.py
@@ -1601,7 +1601,7 @@ class NIRCamFieldAndWavelengthDependentAberration(WebbFieldDependentAberration):
 
             tilt_offset = ctilt_model(wave_um) - ctilt_model(ta_ref_wave)
             _log.info("  Applying OPD tilt adjustment based on NIRCam tilt vs wavelength model")
-            print("  Modified tilt from {} to {} um: {:.3f} nm wfe".format(
+            _log.info("  Modified tilt from {} to {} um: {:.3f} nm wfe".format(
                 ta_ref_wave, wave_um, tilt_offset * 1e9)
             )
 

--- a/webbpsf/tests/test_nircam.py
+++ b/webbpsf/tests/test_nircam.py
@@ -381,8 +381,8 @@ def test_nircam_coron_wfe_offset(fov_pix=15, oversample=2, fit_gaussian=True):
     """
     Test offset of LW coronagraphic PSF w.r.t. wavelength due to optical wedge dispersion.
     Option to fit a Gaussian to PSF core in order to better determine peak position.
-    Difference from 2.5 to 3.3 um should be ~0.015mm.
-    Difference from 3.3 to 5.0 um should be ~0.030mm.
+    Difference from 2.5 to 3.3 um should be ~0.025mm.
+    Difference from 3.3 to 5.0 um should be ~0.021mm.
     """
 
     # Disable Gaussian fit if astropy not installed
@@ -436,12 +436,12 @@ def test_nircam_coron_wfe_offset(fov_pix=15, oversample=2, fit_gaussian=True):
             yloc.append(xvals[yvals==yvals.max()][0])
     yloc = np.array(yloc)
 
-    # Difference from 2.5 to 3.3 um should be ~0.015mm
+    # Difference from 2.5 to 3.3 um should be ~0.025mm
     diff_25_33 = np.abs(yloc[0] - yloc[1])
-    assert np.allclose( diff_25_33, 0.016, rtol=rtol), "PSF shift between {:.2f} and {:.2f} um of {:.3f} mm does not match expected value (~0.016 mm).".format(warr[1], warr[0], diff_25_33)
-    # Difference from 3.3 to 5.0 um should be ~0.030mm
+    assert np.allclose( diff_25_33, 0.025, rtol=rtol), "PSF shift between {:.2f} and {:.2f} um of {:.3f} mm does not match expected value (~0.025 mm).".format(warr[1], warr[0], diff_25_33)
+    # Difference from 3.3 to 5.0 um should be ~0.020mm
     diff_50_33 = np.abs(yloc[2] - yloc[1])
-    assert np.allclose( diff_50_33, 0.032, rtol=rtol), "PSF shift between {:.2f} and {:.2f} um of {:.3f} mm does not match expected value (~0.032 mm).".format(warr[1], warr[2], diff_50_33)
+    assert np.allclose( diff_50_33, 0.021, rtol=rtol), "PSF shift between {:.2f} and {:.2f} um of {:.3f} mm does not match expected value (~0.021 mm).".format(warr[1], warr[2], diff_50_33)
 
 def test_nircam_auto_aperturename():
     """


### PR DESCRIPTION
Update NIRCam coronagraphic wavelength-dependent tilt coefficients. These were miscalculated prior to launch and have since been producing incorrect PSF morphologiers. New values represent actual dispersion from CODEV and Zemax models.

LW example for F444W:
<img width="763" alt="image" src="https://github.com/spacetelescope/webbpsf/assets/17557291/c0e77068-f8ba-4106-b38b-9a3aec2d7942">

SW example for F200W:
<img width="739" alt="image" src="https://github.com/spacetelescope/webbpsf/assets/17557291/619a37af-e4fb-48b0-b519-5a5b17d87e00">
