### PR TITLE
Infrastructure improvements for improved IFU sims

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -58,7 +58,7 @@ jobs:
 
     - name: Get WebbPSF Data
       run: | # Get WebbPSF data files (just a subset of the full dataset!) and set up environment variable
-           wget https://stsci.box.com/shared/static/0ojjfg3cieqdpd18vl1bjnpe63r82dx8.gz -O /tmp/minimal-webbpsf-data.tar.gz
+           wget https://stsci.box.com/shared/static/gkbnn3jwcootr9riwv0rv1t8rpvxl3vr.gz -O /tmp/minimal-webbpsf-data.tar.gz
            tar -xzvf /tmp/minimal-webbpsf-data.tar.gz
            echo "WEBBPSF_PATH=${{github.workspace}}/webbpsf-data" >> $GITHUB_ENV
 

--- a/docs/relnotes.rst
+++ b/docs/relnotes.rst
@@ -27,12 +27,24 @@ See https://github.com/spacetelescope/webbpsf/issues for currently open issues a
 Version History and Change Log
 -------------------------------
 
+Version 1.3.0
+=============
+*Date TBD*
+
+This release comes with new features and improvements including but not limited to:
+
+X. Improved support for NIRSpec and MIRI IFU PSF calculations, including addition of a ``mode`` attribute for toggling between imaging mode and IFU mode simulations; an option for much faster (but slightly simplified) IFU datacube PSF calculations. Spectral bandpass information added for the IFU bands for both NIRSpec and MIRI. For NIRSpec, IFU mode PSF outputs are rotated by an additional 90 degrees to match the convention used in pipeline-output s3d datacubes made using the IFUAlign orientation. This extra rotation can be optionally disabled if so desired; see the NIRSpec class docstring. 
+
+
 Version 1.2.1
 =============
 Minor documentation updates
 
 Version 1.2.0
 =============
+
+*2023 August*
+
 We are pleased to announce the release of the latest version of WebbPSF version 1.2.0, now available on PyPi and GitHub. This release comes with new features and improvements including but not limited to:
 
 1. The addition of detector effects for JWST simulations. H2RG detector effects are included in two flavors, a simple ad hoc Gaussian convolution to model charge diffusion effects and a set of convolution kernels to model interpixel capacitance (IPC) and post-pixel coupling effects. We have found that these effects greatly improve the agreement between observations and simulations. See `JWST Detector Effects for more details. <https://webbpsf.readthedocs.io/en/latest/jwst_detector_effects.html>`_

--- a/webbpsf/__init__.py
+++ b/webbpsf/__init__.py
@@ -40,7 +40,7 @@ if sys.version_info < tuple(
 # required. If changes to the code and data mean WebbPSF won't work
 # properly with an old data package, increment this version number.
 # (It's checked against $WEBBPSF_DATA/version.txt)
-DATA_VERSION_MIN = (1, 2, 1)
+DATA_VERSION_MIN = (1, 3, 0)
 
 
 class Conf(_config.ConfigNamespace):

--- a/webbpsf/tests/test_miri.py
+++ b/webbpsf/tests/test_miri.py
@@ -159,3 +159,12 @@ def test_mode_switch():
     assert miri.detector =='MIRIFUSHORT'
     assert miri.aperturename.startswith('MIRIFU_CH')
     assert miri._rotation != imager_rotation
+
+    # band switching should toggle detector and aper name
+    miri.band = '4C'
+    assert miri.detector == 'MIRIFULONG'
+    assert miri.aperturename == 'MIRIFU_CHANNEL4C'
+
+    miri.band = '2A'
+    assert miri.detector == 'MIRIFUSHORT'
+    assert miri.aperturename == 'MIRIFU_CHANNEL2A'

--- a/webbpsf/tests/test_miri.py
+++ b/webbpsf/tests/test_miri.py
@@ -120,3 +120,10 @@ def test_miri_nonsquare_detector():
     miri = webbpsf_core.MIRI()
     miri.detector_position = (1023, 1031)  # recall this is X, Y order
     assert miri.detector_position == (1023, 1031)
+
+def test_mode_switch():
+    miri = webbpsf_core.MIRI()
+    miri.mode = 'IFU'
+    assert 'IFU' in miri.aperturename
+    miri.mode = 'imaging'
+    assert 'IFU' not in miri.aperturename

--- a/webbpsf/tests/test_miri.py
+++ b/webbpsf/tests/test_miri.py
@@ -122,8 +122,13 @@ def test_miri_nonsquare_detector():
     assert miri.detector_position == (1023, 1031)
 
 def test_mode_switch():
+    """Test switching between imaging and IFU modes, and switching IFU bands
+    Also checks this works to switch aperturenane, and conversely setting aperturename switches mode if needed.
+    Also checks that this automatically changes the rotation and pixelscale properties, as expected.
+    """
     miri = webbpsf_core.MIRI()
     imager_rotation = miri._rotation
+    imager_pixelscale = miri.pixelscale
 
     # Explicitly switch mode to IFU
     miri.mode = 'IFU'
@@ -131,12 +136,15 @@ def test_mode_switch():
     assert miri.detector =='MIRIFUSHORT'
     assert miri.aperturename.startswith('MIRIFU_CH')
     assert miri._rotation != imager_rotation
+    assert miri.pixelscale > imager_pixelscale
     # Explicitly switch back to imaging
     miri.mode = 'imaging'
     assert 'IFU' not in miri.aperturename
     assert miri.detector =='MIRIM'
     assert miri.aperturename.startswith('MIRIM_')
     assert miri._rotation == imager_rotation
+    assert miri.pixelscale == imager_pixelscale
+
 
     # Implicitly switch to IFU 
     miri.set_position_from_aperture_name('MIRIFU_CHANNEL3B')
@@ -144,6 +152,7 @@ def test_mode_switch():
     assert miri.detector =='MIRIFULONG'
     assert miri.aperturename == 'MIRIFU_CHANNEL3B'
     assert miri._rotation != imager_rotation
+    assert miri.pixelscale > imager_pixelscale
 
     # implicitly switch to imaging
     # LRS is an odd case, SLIT aper type but operates like in imaging mode
@@ -152,6 +161,7 @@ def test_mode_switch():
     assert miri.detector =='MIRIM'
     assert miri.aperturename.startswith('MIRIM_')
     assert miri._rotation == imager_rotation
+    assert miri.pixelscale == imager_pixelscale
 
     # And back to IFU again:
     miri.mode = 'IFU'
@@ -159,12 +169,29 @@ def test_mode_switch():
     assert miri.detector =='MIRIFUSHORT'
     assert miri.aperturename.startswith('MIRIFU_CH')
     assert miri._rotation != imager_rotation
+    assert miri.pixelscale > imager_pixelscale
 
     # band switching should toggle detector and aper name
     miri.band = '4C'
     assert miri.detector == 'MIRIFULONG'
     assert miri.aperturename == 'MIRIFU_CHANNEL4C'
+    assert miri.pixelscale > 3*imager_pixelscale
 
     miri.band = '2A'
     assert miri.detector == 'MIRIFUSHORT'
     assert miri.aperturename == 'MIRIFU_CHANNEL2A'
+    assert imager_pixelscale < miri.pixelscale < 2*imager_pixelscale
+
+def test_IFU_wavelengths():
+    """ Test computing the wqvelength sampling for a sim IFU cube """
+    miri = webbpsf_core.MIRI()
+    # check mode swith to IFU
+    miri.mode = 'IFU'
+    miri.band = '2A'
+    waves = miri.get_IFU_wavelengths()
+    assert isinstance(waves, u.Quantity)
+
+    assert len(waves) > 900  # there are lots of wavelengths in MRScubes
+    # and test we can specify a reduced wavelength sampling:
+    for n in (10, 100):
+        assert len(miri.get_IFU_wavelengths(n)) == n

--- a/webbpsf/tests/test_miri.py
+++ b/webbpsf/tests/test_miri.py
@@ -123,7 +123,39 @@ def test_miri_nonsquare_detector():
 
 def test_mode_switch():
     miri = webbpsf_core.MIRI()
+    imager_rotation = miri._rotation
+
+    # Explicitly switch mode to IFU
     miri.mode = 'IFU'
     assert 'IFU' in miri.aperturename
+    assert miri.detector =='MIRIFUSHORT'
+    assert miri.aperturename.startswith('MIRIFU_CH')
+    assert miri._rotation != imager_rotation
+    # Explicitly switch back to imaging
     miri.mode = 'imaging'
     assert 'IFU' not in miri.aperturename
+    assert miri.detector =='MIRIM'
+    assert miri.aperturename.startswith('MIRIM_')
+    assert miri._rotation == imager_rotation
+
+    # Implicitly switch to IFU 
+    miri.set_position_from_aperture_name('MIRIFU_CHANNEL3B')
+    assert 'IFU' in miri.aperturename
+    assert miri.detector =='MIRIFULONG'
+    assert miri.aperturename == 'MIRIFU_CHANNEL3B'
+    assert miri._rotation != imager_rotation
+
+    # implicitly switch to imaging
+    # LRS is an odd case, SLIT aper type but operates like in imaging mode
+    miri.set_position_from_aperture_name('MIRIM_SLIT')
+    assert 'IFU' not in miri.aperturename
+    assert miri.detector =='MIRIM'
+    assert miri.aperturename.startswith('MIRIM_')
+    assert miri._rotation == imager_rotation
+
+    # And back to IFU again:
+    miri.mode = 'IFU'
+    assert 'IFU' in miri.aperturename
+    assert miri.detector =='MIRIFUSHORT'
+    assert miri.aperturename.startswith('MIRIFU_CH')
+    assert miri._rotation != imager_rotation

--- a/webbpsf/tests/test_nirspec.py
+++ b/webbpsf/tests/test_nirspec.py
@@ -52,3 +52,11 @@ def test_calc_datacube_fast():
     waves = np.linspace(3e-6, 5e-6, 3)
 
     cube = nrs.calc_datacube_fast(waves, fov_pixels=30, oversample=1, compare_methods=True)
+
+
+def test_mode_switch():
+    nrs = webbpsf_core.NIRSpec()
+    nrs.mode = 'IFU'
+    assert 'IFU' in nrs.aperturename
+    nrs.mode = 'imaging'
+    assert 'IFU' not in nrs.aperturename

--- a/webbpsf/tests/test_nirspec.py
+++ b/webbpsf/tests/test_nirspec.py
@@ -56,7 +56,16 @@ def test_calc_datacube_fast():
 
 def test_mode_switch():
     nrs = webbpsf_core.NIRSpec()
+    # check mode swith to IFU
     nrs.mode = 'IFU'
     assert 'IFU' in nrs.aperturename
+    assert nrs.band == 'PRISM/CLEAR'
+
+    # check switch of which IFU band
+    nrs.grating = 'G395H'
+    nrs.filter = 'F290LP'
+    assert nrs.band == 'G395H/F290LP'
+
+    # check mode switch back to imaging
     nrs.mode = 'imaging'
     assert 'IFU' not in nrs.aperturename

--- a/webbpsf/tests/test_nirspec.py
+++ b/webbpsf/tests/test_nirspec.py
@@ -55,6 +55,7 @@ def test_calc_datacube_fast():
 
 
 def test_mode_switch():
+    """ Test switch between IFU and imaging modes """
     nrs = webbpsf_core.NIRSpec()
     # check mode swith to IFU
     nrs.mode = 'IFU'
@@ -62,10 +63,25 @@ def test_mode_switch():
     assert nrs.band == 'PRISM/CLEAR'
 
     # check switch of which IFU band
-    nrs.grating = 'G395H'
+    nrs.disperser = 'G395H'
     nrs.filter = 'F290LP'
     assert nrs.band == 'G395H/F290LP'
 
     # check mode switch back to imaging
     nrs.mode = 'imaging'
     assert 'IFU' not in nrs.aperturename
+
+def test_IFU_wavelengths():
+    """ Test computing the wqvelength sampling for a sim IFU cube """
+    nrs = webbpsf_core.NIRSpec()
+    # check mode swith to IFU
+    nrs.mode = 'IFU'
+    nrs.disperser = 'G235H'
+    nrs.filter = 'F170LP'
+    waves = nrs.get_IFU_wavelengths()
+    assert isinstance(waves, u.Quantity)
+
+    assert len(waves) > 3000  # there are lots of wavelengths in the high-resolution grating cubes
+    # and test we can specify a reduced wavelength sampling:
+    for n in (10, 100):
+        assert len(nrs.get_IFU_wavelengths(n)) == n

--- a/webbpsf/utils.py
+++ b/webbpsf/utils.py
@@ -976,7 +976,7 @@ def determine_inst_name_from_v2v3(v2v3):
         _log.debug('Field coordinates determined to be in NIRSpec field')
     elif (
         (v2v3[0] <= -6.2 * u.arcmin)
-        and (v2v3[0] >= -8.3 * u.arcmin)
+        and (v2v3[0] >= -8.5 * u.arcmin)
         and (v2v3[1] <= -5.2 * u.arcmin)
         and (v2v3[1] >= -7.3 * u.arcmin)
     ):

--- a/webbpsf/webbpsf_core.py
+++ b/webbpsf/webbpsf_core.py
@@ -996,6 +996,9 @@ class JWInstrument(SpaceTelescopeInstrument):
                 self._aperturename = value
                 # Update DetectorGeometry class
                 self._detector_geom_info = DetectorGeometry(self.siaf, self._aperturename)
+                if not has_custom_pixelscale:
+                    self.pixelscale = self._get_pixelscale_from_apername(value)
+                    _log.debug( f"Pixelscale updated to {self.pixelscale} based on IFU cubepars for {value}")
 
             else:
                 if self.detector not in value:
@@ -2326,8 +2329,12 @@ class MIRI(JWInstrument_with_IFU):
         """Simple utility function to look up pixelscale from apername"""
 
         if 'MIRIFU' in apername:
-            print('special case for MIRI IFU pixelscales')
-            return 0.1
+            if apername.startswith('MIRIFU_CHANNEL'):
+                band = apername[-2:]
+                spaxelsize, _, _, _= self._IFU_bands_cubepars[band]
+                return spaxelsize
+            else:
+                raise RuntimeError(f"Not sure how to determine pixelscale for {apername}")
         else:
             return super()._get_pixelscale_from_apername(apername)
 
@@ -2401,7 +2408,6 @@ class MIRI(JWInstrument_with_IFU):
         if value in self._IFU_bands_cubepars.keys():
             self._band = value
             #self._slice_width = self._IFU_pixelscale[f"Ch{self._band[0]}"][0]
-
             self.aperturename = 'MIRIFU_CHANNEL' + value
             # setting aperturename will also auto update self._rotation
             #self._rotation = self.MRS_rotation[self._band]
@@ -3246,7 +3252,6 @@ class NIRSpec(JWInstrument_with_IFU):
     def _get_pixelscale_from_apername(self, apername):
         """Simple utility function to look up pixelscale from apername"""
         if 'IFU' in apername:
-            print('DEBUG - special case for NIRSpec IFU pixelscales')
             return super()._get_pixelscale_from_apername('NRS1_FULL')
         else:
             return super()._get_pixelscale_from_apername(apername)

--- a/webbpsf/webbpsf_core.py
+++ b/webbpsf/webbpsf_core.py
@@ -993,6 +993,8 @@ class JWInstrument(SpaceTelescopeInstrument):
 
                 # Now apply changes:
                 self._aperturename = value
+                # Update DetectorGeometry class
+                self._detector_geom_info = DetectorGeometry(self.siaf, self._aperturename)
 
             else:
                 if self.detector not in value:
@@ -1068,10 +1070,14 @@ class JWInstrument(SpaceTelescopeInstrument):
             detname = aperture_name.split('_')[0]
 
             if detname.startswith('MIRIFU'):
+                self._mode = 'IFU'
                 if 'CHANNEL1' in aperture_name or 'CHANNEL2' in aperture_name:
                     self.detector = 'MIRIFUSHORT'
                 else:
                     self.detector = 'MIRIFULONG'
+            elif detname.startswith('MIRIM'):
+                self._mode = 'imaging'
+                self.detector = detname  # As a side effect this auto reloads SIAF info, see detector.setter
 
             elif detname != 'NRS':  # Many NIRSpec slit apertures are defined generally, not for a specific detector
                 self.detector = detname  # As a side effect this auto reloads SIAF info, see detector.setter
@@ -1990,6 +1996,25 @@ class MIRI(JWInstrument_with_IFU):
         # The above tuples give the pixel resolution (perpendicular to the slice, along the slice).
         # The pixels are not square.
 
+        # Mappings between alternate names used for MRS subbands
+        self._MRS_dichroic_to_subband = {"SHORT": "A", "MEDIUM": "B", "LONG": "C"}
+        self._MRS_subband_to_dichroic = {"A": "SHORT", "B": "MEDIUM", "C": "LONG"}
+
+        self._band = None
+        self._MRS_bands = {"1A": [4.887326748103221, 5.753418963216559],   # Values provided by Polychronis Patapis
+                           "1B": [5.644625711181792, 6.644794583147869],   # To-do: obtain from CRDS pipeline refs
+                           "1C": [6.513777066360325, 7.669147994055998],
+                           "2A": [7.494966046398437, 8.782517027772244],
+                           "2B": [8.651469658142522, 10.168811217793243],
+                           "2C": [9.995281242621394, 11.73039280033565],
+                           "3A": [11.529088518317131, 13.491500288051483],
+                           "3B": [13.272122736770127, 15.550153182343314],
+                           "3C": [15.389530615108631, 18.04357852656418],
+                           "4A": [17.686540162850203, 20.973301482912323],
+                           "4B": [20.671069749545193, 24.476094964546686],
+                           "4C": [24.19608171436692, 28.64871057821349]}
+
+
         self._detectors = {'MIRIM': 'MIRIM_FULL',  # Mapping from user-facing detector names to SIAF entries.
                            'MIRIFUSHORT': 'MIRIFU_CHANNEL1A',   # only applicable in IFU mode
                            'MIRIFULONG': 'MIRIFU_CHANNEL3A'}    # ditto
@@ -2228,8 +2253,12 @@ class MIRI(JWInstrument_with_IFU):
                 apname = 'MIRIM_FULL'  # LRS slit uses full array readout
             else:
                 apname = self._image_mask_apertures[self._image_mask]
-        else:
+        elif self.mode == 'imaging':
             apname = 'MIRIM_FULL'
+        else:
+            # IFU mode is complex, don't try to set a different apname here
+            # (This gracefully works around an edge case in mode switching)
+            apname = self.aperturename
 
         # Call aperturename.setter to update ap ref coords and DetectorGeometry class
         self.aperturename = apname
@@ -2258,6 +2287,88 @@ class MIRI(JWInstrument_with_IFU):
             return 0.1
         else:
             return super()._get_pixelscale_from_apername(apername)
+
+    def _get_aperture_rotation(self, apername):
+        """Get the rotation angle of a given aperture, using values from SIAF.
+
+        Returns ~ position angle counterclockwise from the V3 axis, in degrees
+        (i.e. consistent with SIAF V3IdlYangle)
+
+        Note, MIRIFU aperture geometry is extremely complex, and this oversimplifies.
+        See https://jwst-docs.stsci.edu/jwst-mid-infrared-instrument/miri-instrumentation/miri-mrs-field-and-coordinates
+        Consistent with that reference, we compute the angle of the along-slice (alpha) direction relative to the
+        horizontal (V2). Because the apertuers are skewed, this yields different values by several degrees
+        than an equivalent calculation for beta.
+        """
+        if apername.startswith('MIRIM'):
+            return self.siaf['MIRIM_FULL'].V3IdlYAngle
+        elif apername.startswith('MIRIFU'):
+            # These SLIT or COMPOUND apertures do not have a V3IdlYangle param defined in SIAF
+            # But we can work out the angles from the aperture corner vertices which are defined.
+            cx, cy = self.siaf[apername].corners('tel', rederive=False)
+            # The aperture shapes are irregular quadrilaterals, not squares or rectangles
+            # So, take the angles of both alpha-axis (~horizontal) sides, and average them to get an average rotation angle
+            dx = cx[0] - cx[1]
+            dy = cy[0] - cy[1]
+            dx2 = cx[3] - cx[2]
+            dy2 = cy[3] - cy[2]
+            # take the average, and convert to degrees.
+            # The signs and parity of the arctan2 are atypical here, to match the expected output convention of
+            # rotation counterclockwise relative to the V2V3 frame.
+            avg_V3IdlYangle = np.rad2deg((np.arctan2(dy, -dx) + np.arctan2(dy2, -dx2)) / 2)
+            return avg_V3IdlYangle
+        else:
+            raise ValueError(f"Unexpected/invalid apername for MIRI: {apername}")
+
+
+    @JWInstrument_with_IFU.aperturename.setter
+    def aperturename(self, value):
+        """Set aperturename, also update the rotation for MIRIM vs. IFU channel """
+        # apply the provided aperture name
+        # Note, the syntax for calling a parent class property setter is... painful:
+        super(MIRI, type(self)).aperturename.fset(self, value)
+        # Update the rotation angle
+        self._rotation = self._get_aperture_rotation(self.aperturename)
+
+        # if it's an IFU aperture, we're now in IFU mode:
+        self._mode = 'IFU' if value.startswith('MIRIFU') else 'imaging'
+        # if in IFU mode, we probably also want to update the IFU band
+
+        if self.mode == 'IFU':
+            if self.band != value[-2:]:
+                self.band = value[-2:]
+
+
+    @property
+    def band(self):
+        """MRS IFU spectral band. E.g. '1A', '3B'. Only applicable in IFU mode."""
+        if self.mode == 'IFU':
+            return self._band
+        else:
+            return None
+
+    @band.setter
+    def band(self, value):
+        if self.mode != 'IFU':
+            if value is not None:
+                raise RuntimeError("The 'band' property is only valid for IFU mode simulations.")
+            return
+
+        if value in self._MRS_bands.keys():
+            self._band = value
+            #self._slice_width = self._IFU_pixelscale[f"Ch{self._band[0]}"][0]
+
+            self.aperturename = 'MIRIFU_CHANNEL' + value
+            # setting aperturename will also auto update self._rotation
+            #self._rotation = self.MRS_rotation[self._band]
+            # update filter, image_mask and detector
+            #self._filter = "D"+ self.subband_to_dichroic[self._band[1]]
+            #self._image_mask = "MIRI-IFU_" + self._band[0]
+            #self._update_detector()
+        #if not (self.MRSbands[self.band][0] <= self._wavelength <= self.MRSbands[self.band][1]):
+        #    self._wavelength = np.mean(self.MRSbands[self.band])
+        else:
+            raise ValueError(f"Not a valid MRS band: {value}")
 
 class NIRCam(JWInstrument):
     """A class modeling the optics of NIRCam.

--- a/webbpsf/webbpsf_core.py
+++ b/webbpsf/webbpsf_core.py
@@ -2337,6 +2337,7 @@ class MIRI(JWInstrument_with_IFU):
         if self.mode == 'IFU':
             if self.band != value[-2:]:
                 self.band = value[-2:]
+            self._detector = 'MIRIFULONG' if self.band[0] in ['3', '4'] else 'MIRIFUSHORT'
 
 
     @property

--- a/webbpsf/webbpsf_core.py
+++ b/webbpsf/webbpsf_core.py
@@ -1252,7 +1252,12 @@ class JWInstrument(SpaceTelescopeInstrument):
                 # Apply distortion effects to MIRI psf: Distortion and MIRI Scattering
                 _log.debug('MIRI: Adding optical distortion and Si:As detector internal scattering')
                 if self.mode != 'IFU':
-                    psf_siaf = distortion.apply_distortion(result)  # apply siaf distortion
+                    if self._detector_geom_info.aperture.AperType != 'SLIT':
+                        psf_siaf = distortion.apply_distortion(result)  # apply siaf distortion
+                    else:
+                        # slit type aperture, specifically LRS SLIT, does not have distortion polynomials
+                        # therefore omit apply_distortion if a SLIT aperture is selected.
+                        psf_siaf = result
                     psf_siaf_rot = detectors.apply_miri_scattering(psf_siaf)  # apply scattering effect
                     psf_distorted = detectors.apply_detector_charge_diffusion(psf_siaf_rot,options)  # apply detector charge transfer model
                 else:

--- a/webbpsf/webbpsf_core.py
+++ b/webbpsf/webbpsf_core.py
@@ -23,6 +23,7 @@ import os
 import glob
 from collections import namedtuple, OrderedDict
 import functools
+from abc import ABC, abstractmethod
 import numpy as np
 import scipy.interpolate, scipy.ndimage
 
@@ -1825,6 +1826,10 @@ class JWInstrument(SpaceTelescopeInstrument):
 
         # Allow up to 10,000 wavelength slices. The number matters because FITS
         # header keys can only have up to 8 characters. Backward-compatible.
+
+        if isinstance(wavelengths, units.Quantity):
+            wavelengths = wavelengths.to_value(units.m)
+
         nwavelengths = len(wavelengths)
         if nwavelengths < 100:
             label_wl = lambda i: 'WAVELN{:02d}'.format(i)
@@ -1915,7 +1920,7 @@ class JWInstrument(SpaceTelescopeInstrument):
 
         return cubefast
 
-class JWInstrument_with_IFU(JWInstrument):
+class JWInstrument_with_IFU(JWInstrument, ABC):
     """ Subclass which adds some additional infrastructure for IFU sims"""
 
 
@@ -1925,6 +1930,8 @@ class JWInstrument_with_IFU(JWInstrument):
         self._modes_list = {'imaging': None,
                             'IFU': None}
         self._mode = 'imaging'
+
+        self._IFU_bands_cubepars = {}  # placeholder, subclass should implement
 
     @property
     def mode(self):
@@ -1938,6 +1945,26 @@ class JWInstrument_with_IFU(JWInstrument):
             raise ValueError(f"'{value} is not an allowed mode for this instrument.")
         self._mode = value
         self.set_position_from_aperture_name(self._modes_list[value])
+
+    @property
+    @abstractmethod
+    def band(self):
+        # Subclass must implement this
+        pass
+
+    def get_IFU_wavelengths(self, nlambda=None):
+        """Return an array of wavelengths spanning the currently selected IFU sub-band
+        """
+        if self.mode != 'IFU':
+            raise RuntimeError("This method only applies in IFU mode")
+        spaxelsize, wavestep, minwave, maxwave = self._IFU_bands_cubepars[self.band]
+        if nlambda:
+            # Return the specified number of wavelengths, across that band
+            return np.linspace(minwave, maxwave, nlambda) * units.micron
+        else:
+            # Return wavelength across that band using the same spectral sampling
+            # as the instrument and pipeline
+            return np.arange(minwave, maxwave, wavestep) * units.micron
 
 
 class MIRI(JWInstrument_with_IFU):
@@ -1988,32 +2015,48 @@ class MIRI(JWInstrument_with_IFU):
 
         self.monochromatic = 8.0
         self._IFU_pixelscale = {
-            'Ch1': (0.18, 0.19),
-            'Ch2': (0.28, 0.19),
-            'Ch3': (0.39, 0.24),
-            'Ch4': (0.64, 0.27),
+            'Ch1': (0.176, 0.196),
+            'Ch2': (0.277, 0.196),
+            'Ch3': (0.387, 0.245),
+            'Ch4': (0.645, 0.273),
         }
-        # The above tuples give the pixel resolution (perpendicular to the slice, along the slice).
-        # The pixels are not square.
+        # The above tuples give the pixel resolution (first the 'alpha' direction, perpendicular to the slice,
+        # then the 'beta' direction, along the slice).
+        # The pixels are not square.  See https://jwst-docs.stsci.edu/jwst-mid-infrared-instrument/miri-observing-modes/miri-medium-resolution-spectroscopy
 
         # Mappings between alternate names used for MRS subbands
         self._MRS_dichroic_to_subband = {"SHORT": "A", "MEDIUM": "B", "LONG": "C"}
         self._MRS_subband_to_dichroic = {"A": "SHORT", "B": "MEDIUM", "C": "LONG"}
 
         self._band = None
-        self._MRS_bands = {"1A": [4.887326748103221, 5.753418963216559],   # Values provided by Polychronis Patapis
-                           "1B": [5.644625711181792, 6.644794583147869],   # To-do: obtain from CRDS pipeline refs
-                           "1C": [6.513777066360325, 7.669147994055998],
-                           "2A": [7.494966046398437, 8.782517027772244],
-                           "2B": [8.651469658142522, 10.168811217793243],
-                           "2C": [9.995281242621394, 11.73039280033565],
-                           "3A": [11.529088518317131, 13.491500288051483],
-                           "3B": [13.272122736770127, 15.550153182343314],
-                           "3C": [15.389530615108631, 18.04357852656418],
-                           "4A": [17.686540162850203, 20.973301482912323],
-                           "4B": [20.671069749545193, 24.476094964546686],
-                           "4C": [24.19608171436692, 28.64871057821349]}
-
+#        self._MRS_bands = {"1A": [4.887326748103221, 5.753418963216559],   # Values provided by Polychronis Patapis
+#                           "1B": [5.644625711181792, 6.644794583147869],   # To-do: obtain from CRDS pipeline refs
+#                           "1C": [6.513777066360325, 7.669147994055998],
+#                           "2A": [7.494966046398437, 8.782517027772244],
+#                           "2B": [8.651469658142522, 10.168811217793243],
+#                           "2C": [9.995281242621394, 11.73039280033565],
+#                           "3A": [11.529088518317131, 13.491500288051483],
+#                           "3B": [13.272122736770127, 15.550153182343314],
+#                           "3C": [15.389530615108631, 18.04357852656418],
+#                           "4A": [17.686540162850203, 20.973301482912323],
+#                           "4B": [20.671069749545193, 24.476094964546686],
+#                           "4C": [24.19608171436692, 28.64871057821349]}
+        self._IFU_bands_cubepars = {  # pipeline data cube parameters
+                # Taken from ifucubepars_table in CRDS file 'jwst_miri_cubepar_0014.fits', current as of 2023 December
+                # Each tuple gives pipeline spaxelsize, spectralstep, wave_min, wave_max
+                '1A': (0.13, 0.0008, 4.90, 5.74),
+                '1B': (0.13, 0.0008, 5.66, 6.63),
+                '1C': (0.13, 0.0008, 6.53, 7.65),
+                '2A': (0.17, 0.0013, 7.51, 8.77),
+                '2B': (0.17, 0.0013, 8.67, 10.13),
+                '2C': (0.17, 0.0013, 10.01, 11.70),
+                '3A': (0.20, 0.0025, 11.55, 13.47),
+                '3B': (0.20, 0.0025, 13.34, 15.57),
+                '3C': (0.20, 0.0025, 15.41, 17.98),
+                '4A': (0.35, 0.0060, 17.70, 20.95),
+                '4B': (0.35, 0.0060, 20.69, 24.48),
+                '4C': (0.35, 0.0060, 24.40, 28.70),
+        }
 
         self._detectors = {'MIRIM': 'MIRIM_FULL',  # Mapping from user-facing detector names to SIAF entries.
                            'MIRIFUSHORT': 'MIRIFU_CHANNEL1A',   # only applicable in IFU mode
@@ -2355,7 +2398,7 @@ class MIRI(JWInstrument_with_IFU):
                 raise RuntimeError("The 'band' property is only valid for IFU mode simulations.")
             return
 
-        if value in self._MRS_bands.keys():
+        if value in self._IFU_bands_cubepars.keys():
             self._band = value
             #self._slice_width = self._IFU_pixelscale[f"Ch{self._band[0]}"][0]
 
@@ -2370,6 +2413,17 @@ class MIRI(JWInstrument_with_IFU):
         #    self._wavelength = np.mean(self.MRSbands[self.band])
         else:
             raise ValueError(f"Not a valid MRS band: {value}")
+
+    def _calc_psf_format_output(self, result, options):
+        """ Format output HDUList. In particular, add some extra metadata if in IFU mode"""
+        super()._calc_psf_format_output(result, options)
+        if self.mode =='IFU':
+            n_exts = len(result)
+            for ext in np.arange(n_exts):
+                result[ext].header['MODE'] = ("IFU", 'This is a MIRI MRS IFU mode simulation')
+                result[ext].header['FILTER'] = ('MIRIFU_CHANNEL'+self.band, 'MIRI IFU sub-band simulated')
+                result[ext].header['BAND'] = (self.band, 'MIRI IFU sub-band simulated')
+
 
 class NIRCam(JWInstrument):
     """A class modeling the optics of NIRCam.
@@ -3032,6 +3086,20 @@ class NIRSpec(JWInstrument_with_IFU):
         self.image_mask = 'MSA all open'
         self.pupil_mask = self.pupil_mask_list[-1]
 
+        self.disperser_list = ['PRISM', 'G140M', 'G140H', 'G235M', 'G235H', 'G394M', 'G395H']
+        self._disperser = None
+        self._IFU_bands_cubepars  = {
+            'PRISM/CLEAR': (0.10, 0.0050, 0.60, 5.30),
+            'G140M/F070LP': (0.10, 0.0006, 0.70, 1.27),
+            'G140M/F100LP': (0.10, 0.0006, 0.97, 1.89),
+            'G140H/F070LP': (0.10, 0.0002, 0.70, 1.27),
+            'G140H/F100LP': (0.10, 0.0002, 0.97, 1.89),
+            'G235M/F170LP': (0.10, 0.0011, 1.66, 3.17),
+            'G235H/F170LP': (0.10, 0.0004, 1.66, 3.17),
+            'G395M/F290LP': (0.10, 0.0018, 2.87, 5.27),
+            'G395H/F290LP': (0.10, 0.0007, 2.87, 5.27),
+        }
+
         det_list = ['NRS1', 'NRS2']
         self._detectors = dict()
         for name in det_list:
@@ -3148,12 +3216,13 @@ class NIRSpec(JWInstrument_with_IFU):
                     self.pixelscale = self._get_pixelscale_from_apername(detector_apername)
                     _log.debug(f"Pixelscale updated to {self.pixelscale} based on average X+Y SciScale at SIAF aperture {self._aperturename}")
 
-
                 if 'IFU' in self.aperturename:
                     self._mode = 'IFU'
+                    if self._disperser is None:
+                        self.disperser = 'PRISM'  # Set some default spectral mode
+                        self.filter = 'CLEAR'
                 else:
                     self._mode = 'imaging' # More to implement here later!
-
 
 
     def _tel_coords(self):
@@ -3181,6 +3250,45 @@ class NIRSpec(JWInstrument_with_IFU):
             return super()._get_pixelscale_from_apername('NRS1_FULL')
         else:
             return super()._get_pixelscale_from_apername(apername)
+
+    @property
+    def disperser(self):
+        """NIRSpec spectral dispersing element (grating or prism).
+        Only applies for IFU mode sims, currently; used to help set the
+        wavelength range to simulate
+        """
+        if self.mode =='IFU':
+            return self._disperser
+        else:
+            return None
+
+    @disperser.setter
+    def disperser(self, value):
+        if (value is None) or (value in self.disperser_list):
+            self._disperser = value
+        else:
+            raise RuntimeError(f'Not a valid NIRSpec disperser name: {value}')
+
+    def _calc_psf_format_output(self, result, options):
+        """ Format output HDUList. In particular, add some extra metadata if in IFU mode"""
+        super()._calc_psf_format_output(result, options)
+        if self.mode == 'IFU':
+            n_exts = len(result)
+            for ext in np.arange(n_exts):
+                result[ext].header['MODE'] = ("IFU", 'This is a NIRSpec IFU mode simulation')
+                result[ext].header['GRATING'] = (self.disperser, 'Name of the grating (or prism) element simulated.')
+
+
+    @property
+    def band(self):
+        if self.mode != 'IFU':
+            return None
+
+        return self.disperser + "/" + self.filter
+
+    @band.setter
+    def band(self, value):
+        raise RuntimeError("This is a read-only property. Set grating and/or filter attributes instead.")
 
 
 class NIRISS(JWInstrument):

--- a/webbpsf/webbpsf_core.py
+++ b/webbpsf/webbpsf_core.py
@@ -1784,7 +1784,7 @@ class JWInstrument(SpaceTelescopeInstrument):
         opd_fn = webbpsf.mast_wss.get_opd_at_time(date, verbose=verbose, choice=choice, **kwargs)
         self.load_wss_opd(opd_fn, verbose=verbose, plot=plot, **kwargs)
 
-    def calc_datacube_fast(self, wavelengths, compare_methods=False, *args, **kwargs):
+    def calc_datacube_fast(self, wavelengths, compare_methods=False, outfile=None, *args, **kwargs):
         """Calculate a spectral datacube of PSFs: Simplified, much MUCH faster version.
 
         This is adapted from poppy.Instrument.calc_datacube, optimized and simplified
@@ -1919,6 +1919,11 @@ class JWInstrument(SpaceTelescopeInstrument):
             print(f'Standard way: {t2-t1:.3f} s')
 
             return cube, cubefast, waves, waves2  # return extra stuff for compariosns
+
+        if outfile is not None:
+            cubefast[0].header["FILENAME"] = (os.path.basename(outfile), "Name of this file")
+            cubefast.writeto(outfile, overwrite=True)
+            _log.info("Saved result to " + outfile)
 
         return cubefast
 


### PR DESCRIPTION
Work in progress for adding infrastructure for better IFU simulations, shared between NIRSpec and MIRI classes. 

This PR is heavily inspired by #691 by @patapisp, but has generalized much of the implementation to work across both NIRSpec and MIRI. 

This adds a new intermediate abstract subclass `JWInstrument_with_IFU`, and changes the NIRSpec and MIRI classes to  subclass from that. The benefit will be to allow adding IFU-specialized code shared between the two instruments, but not needed in the other three JW SIs. 

That shared code includes:

- [x] Addition of a `mode` attribute to indicated imaging or IFU major mode
- [x]  move the faster data cube function to this subclass
- [x] Add a `.band` attribute to specify IFU bandpass. The implementation and behavior differs for the two classes, following the instrument designs. For NIRSpec the `band` is like `"G295H/F290LP"`, derived from the `.disperser` and `filter` attributes. For MIRI the `band` is an MRS sub-band, like `3A`. 
   - [x] For NIRSpec, this necessitated also adding filter support for the long-pass filters. This requires an update to the data files, and the data files min version. 
- [x] For both classes, reasonable automatic support for toggling SIAF aperture name and mode, in either direction: setting `mode='IFU'` explicitly will change the aperturename to a relevant IFU aperture. Setting the aperture name to an IFU aperture will invoke IFU mode. The intent is to make it seamless and as automatic as possible for the user to set up a self-consistent calculation. 
- [x] For both classes, a lookup table attribute `._IFU_bands_cubepars`, derived from current CRDS cubepar files, which gives the wavelength range, wavelength sampling, and spaxel size for all bands. 
- [x] A method `get_IFU_wavelengths()` that returns the wavelength sampling for the selected band, based on the cubers values.  This function takes an optional `nlambda` argument to specify some desired sampling across the band; by default it matches the wave step from cubepars, which can be >1000 wavelengths depending on mode. 
- [x] Auto adjust pixel (spaxel) scale based on IFU/imaging mode, and IFU band (for MIRI)
- [x] For NIRSpec, in IFU mode, rotate images to match the IFUalign output orientation. 
- [ ] Do we need any such rotation for MIRI to better match the IFUalign outputs for MIRI too? 
- [ ] Consider for IFU mode updating the default pixel scale to match IFUalign output cubes? Or leave it at the actual detector pixel scale as the default? The user can always simply set the pixel scale manually to a custom value, e.g. `nrs.pixelscale=0.1` 


**Example code:**
_MIRI:_
```py
miri = webbpsf.MIRI()
miri.mode = 'IFU'
miri.band= '2A'
waves = miri.get_IFU_wavelengths()
cube = miri.calc_datacube_fast(waves)
```
_NIRSpec:_
```py
nrs = webbpsf.NIRSpec()
nrs.mode = 'IFU'
nrs.disperser = 'PRISM'
nrs.filter = 'CLEAR'
waves = nrs.get_IFU_wavelengths()
cube = nrs.calc_datacube_fast(waves)
```