### PR TITLE
Coronagraph calcs: add 'coron_include_pre_lyot_plane' option for extra output plane

### DIFF
--- a/webbpsf/tests/test_nircam.py
+++ b/webbpsf/tests/test_nircam.py
@@ -592,3 +592,18 @@ def test_coron_shift(offset_npix_x=4, offset_npix_y=-3, plot=False):
     assert np.isclose(cutout_1.sum(), cutout_2.sum()), "PSF cutout sums should be consistent"
 
     assert np.allclose(cutout_1, cutout_2), "PSF cutouts should be consistent"
+
+def test_coron_extra_lyot_plane():
+    # Test adding the optional output of the WFE prior to the Lyot stop plane
+    nrc = webbpsf_core.NIRCam()
+    nrc.pupil_mask = 'MASKLWB'
+    nrc.image_mask = 'MASKLWB'
+    nrc.filter='F460M'
+
+    psf, planes = nrc.calc_psf(nlambda=1, return_intermediates=True, display=True)
+
+    nrc.options['coron_include_pre_lyot_plane'] = True
+    psf2, planes2 = nrc.calc_psf(nlambda=1, return_intermediates=True, display=True)
+
+    assert len(planes2) == len(planes)+1, "There should be an added plane for coron_include_pre_lyot_plane"
+    assert np.allclose(psf[0].data, psf2[0].data), "The PSF output should be the same either way"

--- a/webbpsf/webbpsf_core.py
+++ b/webbpsf/webbpsf_core.py
@@ -1959,6 +1959,10 @@ class MIRI(JWInstrument):
         shift_x, shift_y = self._get_pupil_shift()
         rotation = self.options.get('pupil_rotation', None)
 
+        if self.options.get('coron_include_pre_lyot_plane', False) and self.pupil_mask.startswith('MASK'):
+            optsys.add_pupil(poppy.ScalarTransmission(name='Pre Lyot Stop'))
+            optsys.planes[3].wavefront_display_hint = 'intensity'
+
         if self.pupil_mask == 'MASKFQPM':
             optsys.add_pupil(transmission=self._datapath + "/optics/MIRI_FQPMLyotStop.fits.gz",
                              name=self.pupil_mask,
@@ -2502,6 +2506,13 @@ class NIRCam(JWInstrument):
         else:
             optsys.add_pupil(transmission=self._WebbPSF_basepath + "/tricontagon_oversized_4pct.fits.gz",
                              name='filter stop', shift_x=shift_x, shift_y=shift_y, rotation=rotation)
+
+        if self.options.get('coron_include_pre_lyot_plane', False) and self.pupil_mask.startswith('MASK'):
+            optsys.add_pupil(poppy.ScalarTransmission(name='Pre Lyot Stop'), index=3)  # this is before the above plane, but do the insertion here
+                                                             # because of all the hard-coded index=3 above
+
+            optsys.planes[3].wavefront_display_hint = 'intensity'
+
 
         return (optsys, trySAM, SAM_box_size)
 


### PR DESCRIPTION
This is a relatively specialized PR for a technical use case in coronagraph calculations. This adds an option for, when using the return_intermediates option to calc_psf, optionally outputting an additional wavefront plane to return the wavefront in the Lyot plane right _before_ the Lyot stop. 

Example usage: 
```
# setup
nrc = webbpsf.NIRCam()
nrc.pupil_mask = 'MASKLWB'
nrc.image_mask = 'MASKLWB'
nrc.filter='F460M'

# new option
nrc.options['coron_include_pre_lyot_plane'] = True
psf, planes = nrc.calc_psf(nlambda=1, return_intermediates=True, display=True)
```
The output planes will include an extra plane compared to the default, giving the electric field before the Lyot stop. This is useful for visualizing and diagnosing certain aspects of coronagraphic starlight suppression, by visualizing the intensity before/after the Lyot stop: 

![Unknown-5](https://github.com/spacetelescope/webbpsf/assets/1151745/ec0a97a2-9965-4fd4-9a19-caae1e5d2de4)

![Unknown-6](https://github.com/spacetelescope/webbpsf/assets/1151745/64067d74-89fd-4e86-b65b-468de94b6eb9)

