### PR TITLE
fix some display issues in monthly_trending_plot

### DIFF
--- a/webbpsf/trending.py
+++ b/webbpsf/trending.py
@@ -1139,6 +1139,8 @@ def monthly_trending_plot(year, month, verbose=True, instrument='NIRCam', filter
     fig = plt.figure(constrained_layout=False, figsize=(16, 10), )
 
     subfigs = fig.subfigures(2, 1, hspace=0.02, height_ratios=[2, 2], )
+    for sf in subfigs:
+        sf.set_facecolor('none')  # work around display issue that was hiding the connection patches
 
     min_n_im_axes = 12
     im_axes = subfigs[0].subplots(3, max(npoints,min_n_im_axes),
@@ -1229,6 +1231,7 @@ def monthly_trending_plot(year, month, verbose=True, instrument='NIRCam', filter
     plot_index = -1
     from matplotlib.patches import ConnectionPatch
 
+    ax0ymax = axes[0].get_ylim()[1]  # for use in connection patches below
     for i, row in enumerate(opdtable):
         if verbose:
             print(row['fileName'], row['date'],
@@ -1256,7 +1259,7 @@ def monthly_trending_plot(year, month, verbose=True, instrument='NIRCam', filter
 
             # Make a fancy connector line from the OPD plots to the correct time in the time series plots
             # Draw this for all sensing instances pre-move, but no need to repeat for any post-correction sensing
-            cp = ConnectionPatch([0.5, 0], (dates_array[i].plot_date, 150),
+            cp = ConnectionPatch([0.5, 0], (dates_array[i].plot_date, ax0ymax),
                                  coordsA='axes fraction', coordsB='data',
                                  axesA=im_axes[2, plot_index], axesB=axes[0],
                                  color='darkgreen', ls='--', alpha=0.5


### PR DESCRIPTION
Some of the annotations in `monthly_trending_plot` were not showing as intended, in at least some versions of matplotlib. This fixes that. 

Two unrelated issues: the subfigure white backgrounds were hiding some figure annotations, and the connection patches had a hard coded Y value but should instead adapt to the y axis max of the time series plot. 

**Before**:  Note the absence of suptitle and connection patch lines. 

![Unknown-1](https://github.com/spacetelescope/webbpsf/assets/1151745/ae0741d6-7d68-4b2e-a2ae-de8d917fd5c6)

**With this fix:** Those annotations appear as intended. 

![Unknown](https://github.com/spacetelescope/webbpsf/assets/1151745/f24139a0-8ef0-43e8-a74d-6b6e800b47af)

