### PR TITLE
improve MIRI LRS model details

### DIFF
--- a/webbpsf/detectors.py
+++ b/webbpsf/detectors.py
@@ -418,7 +418,8 @@ def apply_miri_scattering(hdulist_or_filename=None, kernel_amp=None):
     # better match the MIRI CDP PSFS. See e.g. MIRI_FM_MIRIMAGE_F560W_PSF_07.02.00.fits
     # and https://github.com/spacetelescope/webbpsf/issues/415
     kernel_amp_corrections = {'F560W': 4.05, 'F770W': 4.1, 'F1000W': 3.8,
-                               'F1130W': 2.5, 'F1280W': 2.5, 'F1065C': 2.5, 'F1140C': 2.5}
+                               'F1130W': 2.5, 'F1280W': 2.5, 'F1065C': 2.5, 'F1140C': 2.5, 
+                              'FND': 3.0}  # FND value is a WAG, interpolating between the F1000W and F1130W values; in reality it varies over that huge bandpass, but we can't compute it per-wavelengthhere.
     # In-flight correction based on measured cycle 1 ePSFs, coarsely
     for k in kernel_amp_corrections:
         kernel_amp_corrections[k] *= 0.5

--- a/webbpsf/tests/test_miri.py
+++ b/webbpsf/tests/test_miri.py
@@ -88,6 +88,20 @@ def test_miri_slit_apertures():
     assert np.isclose(miri._tel_coords()[0].to_value(u.arcsec), ap.V2Ref)
     assert np.isclose(miri._tel_coords()[1].to_value(u.arcsec), ap.V3Ref)
 
+def test_lrs_psf():
+    """Test that we can at least run an LRS mode PSF calculation
+
+    This is not yet a very good test; does not test the correctness of the output at all.
+    """
+    miri = webbpsf_core.MIRI()
+    miri.set_position_from_aperture_name('MIRIM_SLIT')
+    miri.image_mask = 'LRS slit'
+    miri.pupil_mask = 'P750L'
+    psf = miri.calc_psf(nlambda=1)
+
+    assert psf[0].header['APERNAME'] == miri.aperturename == 'MIRIM_SLIT'
+
+
 def test_miri_nonsquare_detector():
     """ Test that we can handle the slightly different
     dimenssions in X and Y of the MIRI detector"""

--- a/webbpsf/webbpsf_core.py
+++ b/webbpsf/webbpsf_core.py
@@ -1960,8 +1960,13 @@ class MIRI(JWInstrument):
             # Per Klaus Pontoppidan: The LRS slit is aligned with the detector x-axis, so that the
             # dispersion direction is along the y-axis.
             # Slit width and height values derived from SIAF PRDOPSSOC-063, 2024 January
+            # Undocumented options allow for offsetting the slit relative to the output pixel grid, to
+            # more precisely match the actual instrument alignment
             optsys.add_image(optic=poppy.RectangularFieldStop(width=4.72345, height=0.51525,
-                                                              rotation=self._rotation, name=self.image_mask))
+                                                              rotation=self._rotation, name=self.image_mask,
+                                                              shift_x=self.options.get('lrs_slit_offset_x', None),
+                                                              shift_y=self.options.get('lrs_slit_offset_y', None),
+                                                              ))
             trySAM = False
         else:
             optsys.add_image()

--- a/webbpsf/webbpsf_core.py
+++ b/webbpsf/webbpsf_core.py
@@ -1823,8 +1823,10 @@ class MIRI(JWInstrument):
         self._rotation = 4.83544897  # V3IdlYAngle, Source: SIAF PRDOPSSOC-059
                                 # This is rotation counterclockwise; when summed with V3PA it will yield the Y axis PA on sky
 
-        self.options['pupil_shift_x'] = -0.0069 # CV3 on-orbit estimate (RPT028027) + OTIS delta from predicted (037134)
-        self.options['pupil_shift_y'] = -0.0027
+        # Coordinate system note: The pupil shifts get applied at the instrument pupil, which is an image of the OTE exit pupil
+        # and is thus flipped in Y relative to the V frame entrance pupil. Therefore flip sign of pupil_shift_y
+        self.options['pupil_shift_x'] = -0.0068  # In flight measurement. See Wright, Sabatke, Telfer 2022, Proc SPIE 
+        self.options['pupil_shift_y'] = -0.0110  # Sign intentionally flipped relative to that paper!! See note above.
 
         self.image_mask_list = ['FQPM1065', 'FQPM1140', 'FQPM1550', 'LYOT2300', 'LRS slit']
         self.pupil_mask_list = ['MASKFQPM', 'MASKLYOT', 'P750L']

--- a/webbpsf/webbpsf_core.py
+++ b/webbpsf/webbpsf_core.py
@@ -1956,7 +1956,8 @@ class MIRI(JWInstrument):
             #
             # Per Klaus Pontoppidan: The LRS slit is aligned with the detector x-axis, so that the
             # dispersion direction is along the y-axis.
-            optsys.add_image(optic=poppy.RectangularFieldStop(width=4.7, height=0.51,
+            # Slit width and height values derived from SIAF PRDOPSSOC-063, 2024 January
+            optsys.add_image(optic=poppy.RectangularFieldStop(width=4.72345, height=0.51525,
                                                               rotation=self._rotation, name=self.image_mask))
             trySAM = False
         else:
@@ -1995,12 +1996,14 @@ class MIRI(JWInstrument):
                              name='filter cold stop', shift_x=shift_x, shift_y=shift_y, rotation=rotation)
             # FIXME this is probably slightly oversized? Needs to have updated specifications here.
 
-        if self.include_si_wfe:
-            # now put back in the aberrations we grabbed above.
-            optsys.add_pupil(miri_aberrations)
-
         optsys.add_rotation(-self._rotation, hide=True)
         optsys.planes[-1].wavefront_display_hint = 'intensity'
+
+        if self.include_si_wfe:
+            # now put back in the aberrations we grabbed above.
+            # Note, the SI WFE models are in the detector coordinate frame, so this has to be added
+            # *after* the rotation by ~5 degrees to that frame.
+            optsys.add_pupil(miri_aberrations)
 
         return (optsys, trySAM, SAM_box_size if trySAM else None)
 

--- a/webbpsf/webbpsf_core.py
+++ b/webbpsf/webbpsf_core.py
@@ -1962,11 +1962,19 @@ class MIRI(JWInstrument):
             # Slit width and height values derived from SIAF PRDOPSSOC-063, 2024 January
             # Undocumented options allow for offsetting the slit relative to the output pixel grid, to
             # more precisely match the actual instrument alignment
-            optsys.add_image(optic=poppy.RectangularFieldStop(width=4.72345, height=0.51525,
+            lrs_slit = poppy.RectangularFieldStop(width=4.72345, height=0.51525,
                                                               rotation=self._rotation, name=self.image_mask,
                                                               shift_x=self.options.get('lrs_slit_offset_x', None),
                                                               shift_y=self.options.get('lrs_slit_offset_y', None),
-                                                              ))
+                                                              )
+            if self.options.get('lrs_use_mft',True):
+                # Force the LRS slit to be rasterized onto a fine spatial sampling with gray subpixels
+                # let's do a 3 arcsec box, sampled to 0.02 arcsec, with gray subpixels; note poppy does not support non-square wavefront here
+                lrs_pixscale = 0.02 # implicitly u.arcsec/u.pixel
+                sampling = poppy.Wavefront(npix=int(5.5/lrs_pixscale), pixelscale=lrs_pixscale)
+                lrs_slit = poppy.fixed_sampling_optic(lrs_slit, sampling, oversample=8)
+
+            optsys.add_image(optic=lrs_slit)
             trySAM = False
         else:
             optsys.add_image()

--- a/webbpsf/webbpsf_core.py
+++ b/webbpsf/webbpsf_core.py
@@ -1124,9 +1124,7 @@ class JWInstrument(SpaceTelescopeInstrument):
 
         # Add distortion if set in calc_psf
         if add_distortion:
-            _log.debug("Adding PSF distortion(s)")
-            if self.image_mask == "LRS slit" and self.pupil_mask == "P750L":
-                raise NotImplementedError("Distortion is not implemented yet for MIRI LRS mode.")
+            _log.debug("Adding PSF distortion(s) and detector effects")
 
             # Set up new extensions to add distortion to:
             n_exts = len(result)
@@ -1147,8 +1145,11 @@ class JWInstrument(SpaceTelescopeInstrument):
             elif self.name == "MIRI":
                 # Apply distortion effects to MIRI psf: Distortion and MIRI Scattering
                 _log.debug("MIRI: Adding optical distortion and Si:As detector internal scattering")
-                psf_siaf = distortion.apply_distortion(result)  # apply siaf distortion
-                psf_siaf_rot = detectors.apply_miri_scattering(psf_siaf)  # apply scattering effect
+                if self.image_mask != "LRS slit" and self.pupil_mask != "P750L":
+                    psf_siaf = distortion.apply_distortion(result)  # apply siaf distortion
+                else:
+                    psf_siaf = result  # distortion model in SIAF not available for LRS
+                psf_siaf_rot = detectors.apply_miri_scattering(psf_siaf)  # apply scattering effect (cruciform artifact)
                 psf_distorted = detectors.apply_detector_charge_diffusion(psf_siaf_rot,options)  # apply detector charge transfer model
             elif self.name == "NIRSpec":
                 # Apply distortion effects to NIRSpec psf: Distortion only

--- a/webbpsf/webbpsf_core.py
+++ b/webbpsf/webbpsf_core.py
@@ -1986,9 +1986,15 @@ class MIRI(JWInstrument):
                              name=self.pupil_mask,
                              flip_y=True, shift_x=shift_x, shift_y=shift_y, rotation=rotation)
             optsys.planes[-1].wavefront_display_hint = 'intensity'
-        elif self.pupil_mask == 'P750L':
+        elif self.pupil_mask == 'P750L' or self.image_mask == 'LRS slit':
+            # This oversized pupil stop is present on all MIRI imaging filters, thus should
+            # implicitly be included in all MIRI imager calculations, but in practice for
+            # normal imaging modes, the system pupil stop is defined by the OTE primary, so this
+            # stop has no effect. However for any light passing through the LRS slit, the spatial
+            # filtering leads to diffractive spreading in the subsequen pupil which this should
+            # be included for, in order to model slit losses correctly.
             optsys.add_pupil(transmission=self._datapath + "/optics/MIRI_LRS_Pupil_Stop.fits.gz",
-                             name=self.pupil_mask,
+                             name=self.pupil_mask if self.pupil_mask else 'MIRI internal pupil stop',
                              flip_y=True, shift_x=shift_x, shift_y=shift_y, rotation=rotation)
             optsys.planes[-1].wavefront_display_hint = 'intensity'
         else:  # all the MIRI filters have a tricontagon outline, even the non-coron ones.


### PR DESCRIPTION
Address spacetelescope/stpsf#41.

- [x]  Update LRS slit geometry for better consistency with SIAF
- [x] Fixes SI WFE model to be after coordinate rotation to detector frame for LRS mode. (I believe this fix also will slightly improve the model setup for MIRI coronagraphy too. )
- [x] Tunes up cruciform artifact amplitude in LRS mode, using an estimate from F1000W and F1130W.
- [x] Adjust the distortion code to gracefully skip trying to add distortion for LRS, rather than raising an exception.
- [x] Add a basic unit test for running an LRS mode PSF sim. 
 
Remaining open items from spacetelescope/stpsf#41:
- [x]  Pupil stop is correctly set to the oversized tricontagon for the P750L pupil mask, but ought to be set to that for any imaging filter used with the LRS. (or, strictly speaking, in general, but we don't model the effects of the oversized internal pupil stop for regular imaging mode).
- [x]  Need to update pupil shear for this mode using the values from commissioning. See [Wright, Sabatke, and Telfer 2022](https://www.spiedigitallibrary.org/conference-proceedings-of-spie/12180/2632087/James-Webb-Space-Telescope-MIRI-shear-pupil-analysis/10.1117/12.2632087.full#_=_)

Also:
 - [x] Major improvement in LRS slit PSF calculation fidelity through changing the optical propagation to use a much more finely sampled pixelscale for a small region around the LRS slit, computed via MFT. This makes a very significant difference in fine details of LRS PSF sims. 

Defer these as out-of-scope; could be done in some future PR:
- [ ]  Need to understand/double check relative about filter-dependent apparent offsets and how to account for them. In discussion with @skendrew . This may be outside of the scope of webbpsf but relevant for fitting physically-optics-based forward models to data for complex scenes seen via the LRS.
- [ ]  Wavelength-dependent continuous version of the cruciform convolution kernel needed. (Actually I now think this is out of scope for this PR)
- [ ]  SI field dependent WFE: can we get a better estimate of it near the LRS field point? Extrapolate from MIMF sensing near there?  _Edit:_ Descope from this PR. The current estimate is good enough for now. 
