### PR TITLE
Fix obscure error in FITS writing

### DIFF
--- a/webbpsf/webbpsf_core.py
+++ b/webbpsf/webbpsf_core.py
@@ -419,7 +419,7 @@ class SpaceTelescopeInstrument(poppy.instrument.Instrument):
         optsys.add_pupil(pupil_optic)
 
         pupil_rms_wfe_nm = np.sqrt(np.mean(pupil_optic.opd[pupil_optic.amplitude == 1] ** 2)) * 1e9
-        self._extra_keywords['TEL_WFE'] = (pupil_rms_wfe_nm, '[nm] Telescope pupil RMS wavefront error')
+        self._extra_keywords['TEL_WFE'] = (float(pupil_rms_wfe_nm), '[nm] Telescope pupil RMS wavefront error')
         if hasattr(pupil_optic, 'header_keywords'):
             self._extra_keywords.update(pupil_optic.header_keywords())
 
@@ -446,7 +446,7 @@ class SpaceTelescopeInstrument(poppy.instrument.Instrument):
                 # though with a flip in the Y axis to account for entrance vs. exit pupil conventions
                 exit_pupil_mask = pupil_optic.amplitude[::-1] == 1
                 inst_rms_wfe_nm = np.sqrt(np.mean(aberration_optic.opd[exit_pupil_mask] ** 2)) * 1e9
-                self._extra_keywords['SI_WFE'] = (inst_rms_wfe_nm, '[nm] instrument pupil RMS wavefront error')
+                self._extra_keywords['SI_WFE'] = (float(inst_rms_wfe_nm), '[nm] instrument pupil RMS wavefront error')
             except (TypeError, IndexError):
                 # Currently the above does not work for Roman, but fixing this is deferred to future work
                 pass


### PR DESCRIPTION
This one is a doozy insofar as I think it's really a corner case that triggers it. I have run a code using webbpsf for over a year without issues, and suddenly today it started giving me errors when writing out the final fits file.  I *believe* this is because in this specific configurations I have configured cupy to use my GPU, and some part of something that is being output is outputting a cupy scalar instead of a numpy scalar.  And `astropy.io.fits` is unhappy with that because it doesn't know what to do with cupy arrays (since they aren't supposed to auto-cast since they live in the GPU memory).

The fix, in this PR, is just to explicitly cast the values to be put into the FITS header into floats, rather than depending on the numpy implicit behavior.

I have no idea how to write a test for this given that it is pretty hardware-specific... But I can attest at least that on a g5.xlarge AWS instance (using NVIDIA A10G GPUs), this fixes the error...