### PR TITLE
[SCSB-145] require Python 3.10

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -18,13 +18,13 @@ jobs:
 
           - name: Check for Sphinx doc build errors
             os: ubuntu-latest
-            python: 3.9
+            python: 3.10
             toxenv: docbuild
 
           - name: Try Astropy development version
             os: ubuntu-latest
-            python: 3.9
-            toxenv: py39-astropydev-test
+            python: 3.10
+            toxenv: py310-astropydev-test
 
           - name: Try latest versions of all dependencies
             os: ubuntu-latest
@@ -33,13 +33,13 @@ jobs:
 
           - name: Try minimum supported versions
             os: ubuntu-latest
-            python: 3.9
-            toxenv: py39-legacy-test
+            python: 3.10
+            toxenv: py310-legacy-test
 
           - name: Try released POPPY and PySIAF
             os: ubuntu-latest
-            python: 3.9
-            toxenv: py39-stable-test
+            python: 3.10
+            toxenv: py310-stable-test
             continue-on-error: 'true'
 
     steps:

--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -18,12 +18,12 @@ jobs:
 
           - name: Check for Sphinx doc build errors
             os: ubuntu-latest
-            python: 3.10
+            python: '3.10'
             toxenv: docbuild
 
           - name: Try Astropy development version
             os: ubuntu-latest
-            python: 3.10
+            python: '3.10'
             toxenv: py310-astropydev-test
 
           - name: Try latest versions of all dependencies
@@ -33,12 +33,12 @@ jobs:
 
           - name: Try minimum supported versions
             os: ubuntu-latest
-            python: 3.10
+            python: '3.10'
             toxenv: py310-legacy-test
 
           - name: Try released POPPY and PySIAF
             os: ubuntu-latest
-            python: 3.10
+            python: '3.10'
             toxenv: py310-stable-test
             continue-on-error: 'true'
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -96,7 +96,7 @@ Software Requirements
 
 See `the requirements.txt specification file <https://github.com/spacetelescope/webbpsf/blob/develop/requirements.txt>`_ for the required package dependencies.
 
-**Required Python version**: WebbPSF 1.1 and above require Python 3.9 or higher.
+**Required Python version**: WebbPSF 1.1 and above require Python 3.10 or higher.
 
 The major dependencies are the standard `NumPy, SciPy <http://www.scipy.org/scipylib/download.html>`_, `matplotlib <http://matplotlib.org>`_ stack, and `Astropy <http://astropy.org>`_.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dynamic = [
 readme = "README.rst"
 requires-python = ">=3.10"
 dependencies = [
-    "numpy>=1.20.0",
+    "numpy>=1.21.6",
     "scipy>=1.5.0",
     "matplotlib>=3.2.0",
     "astropy>=5.1.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,18 +1,22 @@
 [build-system]
-requires = ["setuptools >= 61.2",
-            "setuptools_scm[toml]>=3.4.3",
-            "wheel"]
-build-backend = 'setuptools.build_meta'
+requires = [
+    "setuptools >= 61.2",
+    "setuptools_scm[toml]>=3.4.3",
+    "wheel",
+]
+build-backend = "setuptools.build_meta"
 
 [project]
 name = "webbpsf"
 description = "Creates simulated point spread functions for the James Webb Space Telescope"
-authors = [{name = "Association of Universities for Research in Astronomy", email = "help@stsci.edu"}]
-license = {file = "LICENSE.md"}
-dynamic = ["version"]
+authors = [
+    { name = "Association of Universities for Research in Astronomy", email = "help@stsci.edu" },
+]
+dynamic = [
+    "version",
+]
 readme = "README.rst"
-
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dependencies = [
     "numpy>=1.20.0",
     "scipy>=1.5.0",
@@ -25,6 +29,9 @@ dependencies = [
     "synphot>=1.0.0",
     "astroquery>=0.4.6",
 ]
+
+[project.license]
+file = "LICENSE.md"
 
 [project.optional-dependencies]
 test = [
@@ -45,12 +52,16 @@ docs = [
 Homepage = "http://webbpsf.readthedocs.io/"
 github_project = "https://github.com/spacetelescope/webbpsf"
 
-[tool.setuptools.packages]
-find = {namespaces = false}
+[tool.setuptools.packages.find]
+namespaces = false
 
 [tool.setuptools.package-data]
-"*" = ["*.fits, *.csv"]
-"webbpsf.tests" = ["data/*"]
+"*" = [
+    "*.fits, *.csv",
+]
+"webbpsf.tests" = [
+    "data/*",
+]
 
 [tool.setuptools_scm]
 write_to = "webbpsf/version.py"
@@ -64,15 +75,15 @@ norecursedirs = [
     "build",
     "docs/_build",
 ]
-
 astropy_header = "true"
 doctest_plus = "enabled"
 text_file_format = "rst"
 addopts = "-p no:warnings"
 
-
 [tool.coverage.run]
-source = ["webbpsf",]
+source = [
+    "webbpsf",
+]
 omit = [
     "webbpsf/conftest*",
     "webbpsf/cython_version*",

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,9 @@
 [tox]
 envlist =
-    py{39,310,311}-test
-    py{39,310,311}-{poppydev,pysiafdev,astropydev,latest,stable}-test
-    py39-legacy-test
-    py{39,310,311}-{poppydev,pysiafdev}-cov
+    py{310,311,312}-test
+    py{310,311,312}-{poppydev,pysiafdev,astropydev,latest,stable}-test
+    py310-legacy-test
+    py{310,311,312}-{poppydev,pysiafdev}-cov
 
 isolated_build = true
 

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,7 @@ deps =
     pytest-astropy
     poppydev,legacy,astropydev,latest: git+https://github.com/spacetelescope/poppy.git#egg=poppy
     pysiafdev,astropydev: git+https://github.com/spacetelescope/pysiaf.git#egg=pysiaf
-    legacy: numpy==1.20.0
+    legacy: numpy==1.21.6
     legacy: pysiaf==0.11.0
     legacy: astropy==5.1.0
     legacy: astroquery==0.4.6

--- a/tox.ini
+++ b/tox.ini
@@ -38,7 +38,6 @@ commands=
     cov: pytest {posargs} --cov-config=pyproject.toml --cov-report=xml --cov=webbpsf webbpsf/tests/
 
 [testenv:docbuild]
-basepython= python3.9
 passenv= *
 deps=
     sphinx
@@ -56,7 +55,6 @@ commands=
     sphinx-build docs docs/_build
 
 [testenv:codestyle]
-basepython= python3.9
 skip_install = true
 description = check package code style
 deps =


### PR DESCRIPTION
resolves [SCSB-145](https://jira.stsci.edu/browse/SCSB-145)

propagate Astropy's deprecation of Python 3.9 to downstream packages


> [!NOTE]
> this PR was generated automatically by ``batchpr`` :robot: