### PR TITLE
Performance enhancement: avoid repeated slow loads of the SIAF

### DIFF
--- a/webbpsf/distortion.py
+++ b/webbpsf/distortion.py
@@ -7,6 +7,7 @@ from scipy.interpolate import RegularGridInterpolator
 from scipy.ndimage import rotate
 
 from soc_roman_tools.siaf.siaf import RomanSiaf
+import webbpsf.webbpsf_core
 
 def _get_default_siaf(instrument, aper_name):
     """
@@ -39,7 +40,7 @@ def _get_default_siaf(instrument, aper_name):
         siaf = RomanSiaf()
         aper = siaf[aper_name]
     else:
-        siaf = pysiaf.Siaf(siaf_name)
+        siaf = webbpsf.webbpsf_core.get_siaf_with_caching(siaf_name)
         aper = siaf.apertures[aper_name]
 
     return aper

--- a/webbpsf/opds.py
+++ b/webbpsf/opds.py
@@ -1226,7 +1226,7 @@ class OTE_Linear_Model_WSS(OPD):
         elif 'nrs' in control_point_detector:
                 control_point_instr = 'nirspec'
 
-        self.ote_control_point = pysiaf.Siaf(control_point_instr)[self.control_point_fieldpoint.upper()].reference_point('tel')*u.arcsec
+        self.ote_control_point = webbpsf.webbpsf_core.get_siaf_with_caching(control_point_instr)[self.control_point_fieldpoint.upper()].reference_point('tel')*u.arcsec
         
         if zero:
             self.zero()

--- a/webbpsf/optics.py
+++ b/webbpsf/optics.py
@@ -12,6 +12,7 @@ import astropy.units as units
 from scipy.interpolate import griddata, RegularGridInterpolator
 from scipy.ndimage import rotate
 
+from . import webbpsf_core
 from . import utils
 from . import constants
 
@@ -735,7 +736,7 @@ class NIRCam_BandLimitedCoron(poppy.BandLimitedCoron):
             raise NotImplementedError("invalid name for NIRCam occulter: " + self.name)
 
         # EDIT: updated on 8 Dec 2021 to grab offsets directly from pySIAF
-        self.siaf = pysiaf.Siaf('NIRCAM')
+        self.siaf = webbpsf_core.get_siaf_with_caching('NIRCAM')
         self.offset_swb = {filt: self.get_bar_offset_from_siaf(filt, channel='SW')
                            for filt in ["F182M", "F187N", "F210M", "F212N", "F200W", 'narrow']}
         self.offset_lwb = {filt: self.get_bar_offset_from_siaf(filt, channel='LW')

--- a/webbpsf/webbpsf_core.py
+++ b/webbpsf/webbpsf_core.py
@@ -22,6 +22,7 @@ Code by Marshall Perrin <mperrin@stsci.edu>
 import os
 import glob
 from collections import namedtuple, OrderedDict
+import functools
 import numpy as np
 import scipy.interpolate, scipy.ndimage
 
@@ -753,7 +754,7 @@ class JWInstrument(SpaceTelescopeInstrument):
     def __init__(self, *args, **kwargs):
         super(JWInstrument, self).__init__(*args, **kwargs)
 
-        self.siaf = pysiaf.Siaf(self.name)
+        self.siaf = get_siaf_with_caching(self.name)
 
         opd_path = os.path.join(self._datapath, 'OPD')
         self.opd_list = []
@@ -2912,6 +2913,13 @@ def calc_or_load_PSF(filename, inst, overwrite=False, **kwargs):
 
 #########################
 
+@functools.lru_cache
+def get_siaf_with_caching(instrname):
+    """ Parsing and loading the SIAF information is particularly time consuming,
+    (can be >0.1 s per call, so multiple invokations can be a large overhead)
+    Therefore avoid unnecessarily reloading it by caching results.
+    This is a small speed optimization. """
+    return pysiaf.Siaf(instrname)
 
 class DetectorGeometry(object):
     """ Utility class for converting between detector coordinates


### PR DESCRIPTION
Benchmarking revealed that repeated loads of the SIAF information were a very significant overhead on PSF calculations: as much as _half a second_ per total calc_psf call, tested on a Mac M1 Max. Each load of the SIAF costs about 150 milliseconds, and there were (unintentionally) multiple reloads happening within the distortion code, and in some optics and OPD subclasses. This is unnecessary because the SIAF information will always be the same in any given python session (it only changes rarely, with new versions of pysiaf). 

This PR adds a cache function `get_siaf_with_caching` and replaces all JWST SIAF loads with a call to that, resulting in significant speedups: 

**Examples for a single PSF calculation:**

_Without this PR:_
```
%timeit psf = nrc.calc_psf(nlambda=1, fov_pixels=101)
691 ms ± 4.93 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```

_With this PR:_
```
%timeit psf = nrc.calc_psf(nlambda=1, fov_pixels=101)
268 ms ± 3.02 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```

**Examples for running the entire test suite:**

_Without this PR:_
```
> pytest   # run entire test suite
=== 115 passed, 1 xfailed in 303.20s (0:05:03) ===
```
_With this PR:_
```
> pytest   # run entire test suite
=== 115 passed, 1 xfailed in 240.77s (0:04:00) ===
```

```
