### PR TITLE
add delta_wfe_around_time function

### DIFF
--- a/webbpsf/tests/test_trending.py
+++ b/webbpsf/tests/test_trending.py
@@ -22,3 +22,11 @@ def test_monthly_trending_plot_opdtable_param():
     opdtable = webbpsf.mast_wss.filter_opd_table(opdtable0, start_time=pre_start_date, end_time=end_date2)
     trend_table = webbpsf.trending.monthly_trending_plot(2023, 6, opdtable=opdtable, instrument='NIRISS', filter='F380M')
     assert(len(trend_table) == 15)
+
+
+def test_delta_wfe_around_time():
+    """Very basic test - does this hand back something that could be an OPD array
+    Does not check the value in any significant way.
+    """
+    opd = webbpsf.trending.delta_wfe_around_time('2024-02-26')
+    assert opd.shape==(256,256), 'this function should return an OPD with the expected size'

--- a/webbpsf/trending.py
+++ b/webbpsf/trending.py
@@ -17,9 +17,12 @@ import scipy.interpolate
 import poppy
 import webbpsf
 
-def _read_opd(filename):
-    """Trivial utilty function to read OPD from a WSS-output FITS file"""
+def _read_opd(filename, auto_download=True):
+    """Trivial utilty function to read OPD from a WSS-output FITS file
+    If the file does not exist locally, try to retrieve it from MAST automatically."""
     full_file_path = os.path.join(webbpsf.utils.get_webbpsf_data_path(), 'MAST_JWST_WSS_OPDs', filename)
+    if not os.path.exists(full_file_path) and auto_download:
+        webbpsf.mast_wss.mast_retrieve_opd(filename)
     opdhdu = fits.open(full_file_path)
     opd = opdhdu[1].data.copy()
     return opd, opdhdu


### PR DESCRIPTION
@obi-wan76 This is the function I mentioned briefly in slack. Written a while ago but I hadn't yet had a chance to PR it. 

Given any date (or date and time, in the usual string format), this returns the delta OPD between the two measurements around that time.  This should make it relatively easy to make plots of the drifts corresponding to the times when you think you detect strain sensor steps. 


<img width="846" alt="Screen Shot 2024-04-01 at 5 27 38 PM" src="https://github.com/spacetelescope/webbpsf/assets/1151745/e7b1caba-2cfa-4993-9859-876d895f77bf">
