### PR TITLE
avoid linear interpolation between WFE values

### DIFF
--- a/webbpsf/trending.py
+++ b/webbpsf/trending.py
@@ -323,7 +323,7 @@ def wfe_histogram_plot(
     dates = astropy.time.Time(opdtable1['date'], format='isot')
 
     # Interpolate those RMSes into an even grid over time
-    interp_fn = scipy.interpolate.interp1d(mjds, rmses, kind='linear')
+    interp_fn = scipy.interpolate.interp1d(mjds, rmses, kind='nearest')
 
     mjdrange = np.linspace(np.min(mjds), np.max(mjds), 2048)
     interp_rmses = interp_fn(mjdrange)


### PR DESCRIPTION
As discussed on slack with @tracy-beck and Matt Lallo, it's better for the WFE histogram not to interpolate between points when inferring WFE at times in between our measurements. 

**Before this PR:** 
![Unknown-13](https://github.com/spacetelescope/webbpsf/assets/1151745/a7b5b6a7-2af4-45d3-9ffc-975ecfc24e6c)


**With this PR:** 

![Unknown-12](https://github.com/spacetelescope/webbpsf/assets/1151745/c61ee864-f760-4b5f-9004-1a8b62f7fcd1)
