### PR TITLE
bug fix an edge case for switching MIRI apertures

### DIFF
--- a/webbpsf/tests/test_miri.py
+++ b/webbpsf/tests/test_miri.py
@@ -99,6 +99,10 @@ def test_miri_slit_apertures():
     assert np.isclose(miri._tel_coords()[0].to_value(u.arcsec), ap.V2Ref)
     assert np.isclose(miri._tel_coords()[1].to_value(u.arcsec), ap.V3Ref)
 
+    # Test we can switch back from SLIT to regular type apertures without any error
+    miri.set_position_from_aperture_name("MIRIM_SLIT")
+    miri.set_position_from_aperture_name('MIRIM_FULL')
+
 
 def test_lrs_psf():
     """Test that we can at least run an LRS mode PSF calculation

--- a/webbpsf/webbpsf_core.py
+++ b/webbpsf/webbpsf_core.py
@@ -993,8 +993,10 @@ class JWInstrument(SpaceTelescopeInstrument):
                 # The point is to check if the pixel scale is set to a custom or default value,
                 # and if it's custom then don't override that.
                 # Note, check self._aperturename first to account for the edge case when this is called from __init__ before _aperturename is set
+                # and also check neither current nor requested aperture are of type SLIT since that doesn't have a pixelscale to get.
                 has_custom_pixelscale = (
                     self._aperturename
+                    and  (self.siaf[self._aperturename].AperType != 'SLIT')
                     and (self.pixelscale != self._get_pixelscale_from_apername(self._aperturename))
                     and ap.AperType != 'SLIT'
                 )


### PR DESCRIPTION
Fix an edge case in some of the pixel scale checking code which happens when changing apertures. 

Currently, can't switch from a SLIT type aperture back to a regular aperture. The following will fail:
```
miri = webbpsf.MIRI()
miri.set_position_from_aperture_name("MIRIM_SLIT")
miri.set_position_from_aperture_name('MIRIM_FULL')
```

With this PR, the above works without error. 

