### PR TITLE
Update for WFI to use pysiaf instead of soc_roman_tools

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,6 @@ dependencies = [
     "photutils>=1.10.0",
     "poppy>=1.0.0",
     "pysiaf>=0.19.1",
-    "soc_roman_tools>=0.1.0",
     "synphot>=1.0.0",
     "astroquery>=0.4.6",
 ]

--- a/webbpsf/distortion.py
+++ b/webbpsf/distortion.py
@@ -6,7 +6,6 @@ import pysiaf
 from scipy.interpolate import RegularGridInterpolator
 from scipy.ndimage import rotate
 
-from soc_roman_tools.siaf.siaf import RomanSiaf
 import webbpsf.webbpsf_core
 
 
@@ -38,7 +37,7 @@ def _get_default_siaf(instrument, aper_name):
 
     # Select a single SIAF aperture
     if instrument == 'WFI':
-        siaf = RomanSiaf()
+        siaf = pysiaf.Siaf('Roman')
         aper = siaf[aper_name]
     else:
         siaf = webbpsf.webbpsf_core.get_siaf_with_caching(siaf_name)


### PR DESCRIPTION
The Roman SIAF is now available from PySIAF. This PR updates the source code that handles WFI distortion to pull the necessary data from PySIAF instead of `soc_roman_tools`.  I've done a few tests and code runs fins and results are as expected.

Also, as a result of this update, there is no more dependency on `soc_roman_tools`, and it was removed from "pyproject.toml".

