### PR TITLE
Allow specifying NIRCam LW detectors equivalently like 'NRCA5' or 'NRCALONG'

### DIFF
--- a/webbpsf/tests/test_nircam.py
+++ b/webbpsf/tests/test_nircam.py
@@ -623,3 +623,13 @@ def test_coron_extra_lyot_plane():
 
     assert len(planes2) == len(planes) + 1, 'There should be an added plane for coron_include_pre_lyot_plane'
     assert np.allclose(psf[0].data, psf2[0].data), 'The PSF output should be the same either way'
+
+
+def test_ways_to_specify_detectors():
+    nrc = webbpsf_core.NIRCam()
+
+    nrc.detector = 'NRCALONG'
+    assert nrc.detector == 'NRCA5', "NRCALONG should be synonymous to NRCA5"
+
+    nrc.detector = 'nrcblong'
+    assert nrc.detector == 'NRCB5', "nrcblong should be synonymous to nrcb5"

--- a/webbpsf/webbpsf_core.py
+++ b/webbpsf/webbpsf_core.py
@@ -2709,6 +2709,9 @@ class NIRCam(JWInstrument):
     @JWInstrument.detector.setter  # override setter in this subclass, to implement auto channel switch
     def detector(self, value):
         """Set detector, including reloading the relevant info from SIAF"""
+        if value.upper().endswith('LONG'):
+            # treat NRCALONG and NRCBLONG as synonyms to NRCA5 and NRCB5
+            value = value[:-4]+ '5'
         if value.upper() not in self.detector_list:
             raise ValueError('Invalid detector. Valid detector names are: {}'.format(', '.join(self.detector_list)))
         # set the channel based on the requested detector


### PR DESCRIPTION
Issue #660 has been pending and slipped through the cracks, not dealt with for over a year now, about specifying NRCALONG as a synonym for NRCA5 and similarly for B. This is a quick easy fix so I just went ahead and fixed it for this release as well.. 
