### PR TITLE
minor bug fix to IFU mode after #770

### DIFF
--- a/webbpsf/tests/test_nirspec.py
+++ b/webbpsf/tests/test_nirspec.py
@@ -55,6 +55,7 @@ def test_mode_switch():
     nrs.mode = 'IFU'
     assert 'IFU' in nrs.aperturename
     assert nrs.band == 'PRISM/CLEAR'
+    assert nrs.image_mask is None
 
     # check switch of which IFU band
     nrs.disperser = 'G395H'

--- a/webbpsf/webbpsf_core.py
+++ b/webbpsf/webbpsf_core.py
@@ -2115,8 +2115,6 @@ class MIRI(JWInstrument_with_IFU):
 
     def _validate_config(self, **kwargs):
         """Validate instrument config for MIRI"""
-        if self.filter.startswith('MRS-IFU'):
-            raise NotImplementedError('The MIRI MRS is not yet implemented.')
         return super(MIRI, self)._validate_config(**kwargs)
 
     def _addAdditionalOptics(self, optsys, oversample=2):
@@ -3152,8 +3150,6 @@ class NIRSpec(JWInstrument_with_IFU):
         self._si_wfe_class = optics.NIRSpecFieldDependentAberration  # note we end up adding 2 instances of this.
 
     def _validate_config(self, **kwargs):
-        if self.filter.startswith('IFU'):
-            raise NotImplementedError('The NIRSpec IFU is not yet implemented.')
         return super(NIRSpec, self)._validate_config(**kwargs)
 
     def _addAdditionalOptics(self, optsys, oversample=2):
@@ -3269,6 +3265,9 @@ class NIRSpec(JWInstrument_with_IFU):
                     if self._disperser is None:
                         self.disperser = 'PRISM'  # Set some default spectral mode
                         self.filter = 'CLEAR'
+                    if self.image_mask not in ['IFU', None]:
+                        _log.info("The currently-selected image mask (slit) is not compatible with IFU mode. Setting image_mask=None")
+                        self.image_mask = None
                 else:
                     self._mode = 'imaging' # More to implement here later!
 


### PR DESCRIPTION
Minor fix: When switching to NIRSpec IFU mode, don't leave the image_mask at a slit or MSA mask (which is impossible to see with the IFU). 

Specifically the default `image_mask` For NIRSpec is 'MSA all open', and setting `nrs.mode = 'IFU'` would leave `nrs.image_mask == 'MSA all open'` which makes no sense. This PR fixes that. 

It also deletes some very-very-old and obsolete warning checks about filter names starting with IFU and saying the IFU modes are not yet implemented; this is way out of date and no longer needed (and these lines of code were never getting executed anyway). 