### PR TITLE
add test function for the NIRCam DHS support.

### DIFF
--- a/webbpsf/tests/test_nircam.py
+++ b/webbpsf/tests/test_nircam.py
@@ -640,3 +640,14 @@ def test_ways_to_specify_detectors():
 
     nrc.detector = 'nrcblong'
     assert nrc.detector == 'NRCB5', "nrcblong should be synonymous to nrcb5"
+
+def test_dhs():
+    """Basic test that it's possible to calculate a PSF for one of the NIRCam DHS subapertures"""
+    nrc = webbpsf_core.NIRCam()
+
+    nrc.pupil_mask = 'DHS_07'
+
+    psf = nrc.calc_psf(monochromatic=2e-6)
+
+    assert isinstance(psf, fits.HDUList), "the returned PSF should be a FITS HDUList"
+    assert 0.03 < psf[0].data.sum() < 0.05, "a DHS aperture should have low throughput around a few percent"

--- a/webbpsf/tests/test_nircam.py
+++ b/webbpsf/tests/test_nircam.py
@@ -641,6 +641,7 @@ def test_ways_to_specify_detectors():
     nrc.detector = 'nrcblong'
     assert nrc.detector == 'NRCB5', "nrcblong should be synonymous to nrcb5"
 
+
 def test_dhs():
     """Basic test that it's possible to calculate a PSF for one of the NIRCam DHS subapertures"""
     nrc = webbpsf_core.NIRCam()


### PR DESCRIPTION
Add a unit test for the DHS support added in  #845

This tests that we can select one of the DHS sub apertures as a pupil mask, make a PSF, and that the resulting PSF has only a couple percent of the total intensity (as expected, given the small size of these sub apertures)