### PR TITLE
Improve trending plots, particularly wfe_histogram arrows display

### DIFF
--- a/webbpsf/trending.py
+++ b/webbpsf/trending.py
@@ -201,7 +201,7 @@ def wavefront_time_series_plot(
             # Limit events that happened after start_date:
             if d >= start_date and d <= end_date:
                 plt.axvline(d.plot_date, color=color, ls=':', alpha=0.5)
-                ax.text(d.plot_date + 0.25, ymax * 0.95, event, color=color, rotation=90, verticalalignment='top', alpha=0.7)
+                ax.text(d.plot_date + 0.25, ymax * 0.95, event, color=color, rotation=90, verticalalignment='top', alpha=0.7, clip_on=True)
 
     # Connect measurements on the same visit
     for row, rms in zip(opdtable[where_post], rms_nm[where_post]):
@@ -220,7 +220,7 @@ def wavefront_time_series_plot(
             visit = row['visitId']
             short_visit = f'  {int(visit[1:6])}:{int(visit[6:9])}'
             if d_pre.datetime >= start_date and d_pre.datetime <= end_date and rms < ymax:
-                plt.text(d_pre.plot_date, rms, short_visit, rotation=65, color='C0', fontsize=10)
+                plt.text(d_pre.plot_date, rms, short_visit, rotation=65, color='C0', fontsize=10, clip_on=True)
 
     plt.plot(dates.plot_date[where_pre][is_routine], rms_nm[where_pre][is_routine], ls='none', alpha=0.5)
     plt.plot(dates.plot_date[where_post], rms_nm[where_post], ls='none', color='C2', alpha=0.5)

--- a/webbpsf/trending.py
+++ b/webbpsf/trending.py
@@ -201,7 +201,8 @@ def wavefront_time_series_plot(
             # Limit events that happened after start_date:
             if d >= start_date and d <= end_date:
                 plt.axvline(d.plot_date, color=color, ls=':', alpha=0.5)
-                ax.text(d.plot_date + 0.25, ymax * 0.95, event, color=color, rotation=90, verticalalignment='top', alpha=0.7, clip_on=True)
+                ax.text(d.plot_date + 0.25, ymax * 0.95, event, color=color, rotation=90, verticalalignment='top',
+                        alpha=0.7, clip_on=True)
 
     # Connect measurements on the same visit
     for row, rms in zip(opdtable[where_post], rms_nm[where_post]):
@@ -336,7 +337,8 @@ def wfe_histogram_plot(
     interp_rmses = interp_fn(mjdrange)
 
     if max_wfe is not None:
-        interp_rmses = np.clip(interp_rmses, min_wfe/1e3, max_wfe/1e3)  # note this is in microns, so have to rescale max_wfe
+        interp_rmses = np.clip(interp_rmses, min_wfe / 1e3, max_wfe / 1e3)
+        # note the interp_wfe array is in microns, so have to rescale min and max_wfe values before clipping
 
     # Plot
     hspace = 0.3
@@ -345,7 +347,8 @@ def wfe_histogram_plot(
 
     ms = 14  # markersize
 
-    sensing_markers,  = axes[0].plot_date(dates.plot_date, np.asarray(rmses) * 1e3, '.', ms=ms, ls='-', label='Sensing visit')
+    sensing_markers, = axes[0].plot_date(dates.plot_date, np.asarray(rmses) * 1e3, '.', ms=ms, ls='-',
+                                         label='Sensing visit')
     axes[0].xaxis.set_major_locator(matplotlib.dates.DayLocator(bymonthday=[1]))
     axes[0].xaxis.set_minor_locator(matplotlib.dates.DayLocator(interval=1))
     axes[0].tick_params('x', length=10, rotation=30)
@@ -363,7 +366,7 @@ def wfe_histogram_plot(
     elif mark_corrections == 'triangles':
         yval = (np.asarray(rmses) * 1e3).max() * 1.01
         if max_wfe:
-            yval = min(yval, max_wfe*0.98)
+            yval = min(yval, max_wfe * 0.98)
         axes[0].scatter(
             dates[where_post].plot_date,
             np.ones(np.sum(where_post)) * yval,
@@ -379,14 +382,15 @@ def wfe_histogram_plot(
         for i, idate in enumerate(where_post):
             if idate:
                 axes[0].annotate('', xy=(dates[i].plot_date, rms_nm[i]),
-                                 xytext=(dates[i-1].plot_date, rms_nm[i-1] if (max_wfe is None or rms_nm[i-1] < max_wfe) else max_wfe),
+                                 xytext=(dates[i - 1].plot_date, rms_nm[i - 1] if
+                                         (max_wfe is None or rms_nm[i-1] < max_wfe) else max_wfe),
                                  color='limegreen', arrowprops=dict(arrowstyle='-|>', color='limegreen', linewidth=2,
                                                                     mutation_scale=20),
-                                 xycoords='data',
+                                 xycoords='data'
                 )
         arrow_placeholder = matplotlib.lines.Line2D([], [], color='limegreen', marker='v', ls='none',
                                                     markersize=10, label='Corrections')
-        axes[0].legend(handles = [sensing_markers, arrow_placeholder])
+        axes[0].legend(handles=[sensing_markers, arrow_placeholder])
 
     if pid:
         axes[0].set_ylim(0.975 * axes[0].get_ylim()[0], 1.025 * axes[0].get_ylim()[1])

--- a/webbpsf/webbpsf_core.py
+++ b/webbpsf/webbpsf_core.py
@@ -1813,7 +1813,8 @@ class JWInstrument(SpaceTelescopeInstrument):
         opd_fn = webbpsf.mast_wss.get_opd_at_time(date, verbose=verbose, choice=choice, **kwargs)
         self.load_wss_opd(opd_fn, verbose=verbose, plot=plot, **kwargs)
 
-    def calc_datacube_fast(self, wavelengths, compare_methods=False, outfile=None, *args, **kwargs):
+    def calc_datacube_fast(self, wavelengths, compare_methods=False, outfile=None,
+                           add_distortion=True, *args, **kwargs):
         """Calculate a spectral datacube of PSFs: Simplified, much MUCH faster version.
 
         This is adapted from poppy.Instrument.calc_datacube, optimized and simplified
@@ -1846,6 +1847,8 @@ class JWInstrument(SpaceTelescopeInstrument):
         wavelengths : iterable of floats
             List or ndarray or tuple of floating point wavelengths in meters, such as
             you would supply in a call to calc_psf via the "monochromatic" option
+        add_distortion : bool
+            Same as for regular calc_psf.
 
         compare_methods : bool
             If true, compute the PSF **BOTH WAYS**, and return both for comparisons.


### PR DESCRIPTION
Improves the `trending.wfe_histogram_plot` arrow markers to show corrections. 
 - switches to use `matplotlib.annotate` to draw the arrows, instead of separate calls to plot lines and draw triangle markers. This ultimately is cleaner but ended up taking a while to figure out since there's a ridiculously complicated set of options to the arrow-drawing functions.
 - Adds `min_wfe` and `max_wfe` options to that function, which can be used to directly set custom min and max ranges if the defaults aren't suitable in some particular case. The histogram and cumulative histogram display is updates to clip values, such that values outside of min and max are still included in the histogram at the extreme bottom or top bin of the histogram, respectively. 

Example output:

![Unknown-12](https://github.com/spacetelescope/webbpsf/assets/1151745/2b4d653d-e4f5-48d8-ac4f-8ce6ce01a177)



Separately, this PR also has a minor fix to some unrelated display issues elsewhere in `trending.py`, by setting `clip_on=True` in a couple function calls, to prevent labels being drawn outside of axes sometimes depending on x and y ranges there. This is mostly unrelated but is convenient to combine into this same PR. 


