### PR TITLE
minor: trending function add cycle 3 routine WFS PIDs

### DIFF
--- a/webbpsf/trending.py
+++ b/webbpsf/trending.py
@@ -125,6 +125,7 @@ def wavefront_time_series_plot(
         4508,
         4509,
     ]  # Cycle 2
+    routine_pids += list(range(6689, 6699))  # Cycle 3
 
     is_routine = np.asarray([int(v[1:6]) in routine_pids for v in opdtable[where_pre]['visitId']])
 


### PR DESCRIPTION
Very minor PR: Adds the cycle 3 WFS program IDs to the list inside `wavefront_time_series_plot`wavefront_time_series_plot`. This has only the trivial effect of changing the color of the dot used to plot those datapoints. 