### PR TITLE
[CI] add names to workflows and fix data version parsing with `echo` and `awk`

### DIFF
--- a/.github/workflows/download_data.yml
+++ b/.github/workflows/download_data.yml
@@ -22,6 +22,8 @@
 #     with:
 #       minimal: true
 
+name: download and cache data
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/retrieve_cache.yml
+++ b/.github/workflows/retrieve_cache.yml
@@ -62,7 +62,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
       - run: echo ${{ steps.latest_cache_key.outputs.cache_key }}
       - id: version
-        run: echo "version=$(${{ steps.latest_cache_key.outputs.cache_key }} | awk -F '-' '{print $4}')" >> $GITHUB_OUTPUT
+        run: echo "version=$(echo ${{ steps.latest_cache_key.outputs.cache_key }} | awk -F '-' '{print $4}')" >> $GITHUB_OUTPUT
     outputs:
       version: ${{ steps.version.outputs.version }}
       cache_path: ${{ runner.temp }}/webbpsf-data

--- a/.github/workflows/retrieve_cache.yml
+++ b/.github/workflows/retrieve_cache.yml
@@ -27,6 +27,8 @@
 #          key: ${{ needs.webbpsf_data_cache_key.outputs.cache_key }}
 #       ...
 
+name: retrieve latest data cache key
+
 on:
   workflow_call:
     inputs:


### PR DESCRIPTION
the workflows don't have names so it defaults to their filename, which is ugly:
[<img width="280" alt="image" src="https://github.com/user-attachments/assets/84e14bf2-27b0-4709-b56d-3c7758a90741">](https://github.com/spacetelescope/webbpsf/actions)

Additionally, the `version` output was broken because I forgot to include `echo` when piping to `awk`; that's fixed here