### PR TITLE
[CI] set a generalized cache path, allowing multiple data caches to be combined downstream

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -64,11 +64,11 @@ jobs:
     - name: Get WebbPSF Data
       uses: actions/cache/restore@v4
       with:
-        path: ${{ runner.temp }}/webbpsf-data
+        path: ${{ needs.retrieve_cache.outputs.cache_path }}
         key: ${{ needs.retrieve_cache.outputs.cache_key }}
 
     - name: Set WebbPSF data path
-      run: echo "WEBBPSF_PATH=${{ runner.temp }}/webbpsf-data" >> $GITHUB_ENV
+      run: echo "WEBBPSF_PATH=${{ needs.retrieve_cache.outputs.cache_path }}/webbpsf-data/" >> $GITHUB_ENV
 
     - name: Check conda info
       run: conda info

--- a/.github/workflows/download_data.yml
+++ b/.github/workflows/download_data.yml
@@ -58,16 +58,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - run: wget ${{ (github.event_name == 'schedule' || github.event_name == 'release') && env.MINIMAL_DATA_URL || inputs.minimal && env.MINIMAL_DATA_URL || env.DATA_URL }} -O ${{ runner.temp }}/webbpsf-data.tar.gz
-      - run: tar -xzvf ${{ runner.temp }}/webbpsf-data.tar.gz -C ${{ runner.temp }}
+      - run: tar -xzvf ${{ runner.temp }}/webbpsf-data.tar.gz -C ${{ runner.temp }}/data/
       - id: cache_path
-        run: echo cache_path=${{ runner.temp }}/webbpsf-data >> $GITHUB_OUTPUT
+        run: echo cache_path=${{ runner.temp }}/data/ >> $GITHUB_OUTPUT
       - id: version
         run: echo "version=$(cat ${{ steps.cache_path.outputs.cache_path }}/version.txt)" >> $GITHUB_OUTPUT
       - id: cache_key
         run: echo "cache_key=webbpsf-data-${{ (github.event_name == 'schedule' || github.event_name == 'release') && 'mini' || inputs.minimal && 'mini' || 'full' }}-${{ steps.version.outputs.version }}" >> $GITHUB_OUTPUT
       - uses: actions/cache/save@v4
         with:
-          path: ${{ runner.temp }}/webbpsf-data
+          path: ${{ runner.temp }}/data/
           key: ${{ steps.cache_key.outputs.cache_key }}
     outputs:
       version: ${{ steps.version.outputs.version }}

--- a/.github/workflows/retrieve_cache.yml
+++ b/.github/workflows/retrieve_cache.yml
@@ -63,5 +63,5 @@ jobs:
         run: echo "version=$(${{ steps.latest_cache_key.outputs.cache_key }} | awk -F '-' '{print $4}')" >> $GITHUB_OUTPUT
     outputs:
       version: ${{ steps.version.outputs.version }}
-      cache_path: ${{ runner.temp }}/webbpsf-data
+      cache_path: ${{ runner.temp }}/data/
       cache_key: ${{ steps.latest_cache_key.outputs.cache_key }}


### PR DESCRIPTION
since GitHub caching has a quirk where caches are distinguished by both the cache key AND cache path, this should make it much easier to cache WebbPSF data and also CRDS files when running the `romancal` tests, by setting `restore-keys`

This PR changes the cache path as so:
```diff
- ${{ runner.temp }}/webbpsf-data
+ ${{ runner.temp }}/data/
```
where `webbpsf-data/` is stored within `${{ runner.temp }}/data/`