### PR TITLE
[CI] fix missing `data/` directory when downloading + caching data

### DIFF
--- a/.github/workflows/download_data.yml
+++ b/.github/workflows/download_data.yml
@@ -60,6 +60,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - run: wget ${{ (github.event_name == 'schedule' || github.event_name == 'release') && env.MINIMAL_DATA_URL || inputs.minimal && env.MINIMAL_DATA_URL || env.DATA_URL }} -O ${{ runner.temp }}/webbpsf-data.tar.gz
+      - run: mkdir ${{ runner.temp }}/data/
       - run: tar -xzvf ${{ runner.temp }}/webbpsf-data.tar.gz -C ${{ runner.temp }}/data/
       - id: cache_path
         run: echo cache_path=${{ runner.temp }}/data/ >> $GITHUB_OUTPUT

--- a/.github/workflows/download_data.yml
+++ b/.github/workflows/download_data.yml
@@ -65,7 +65,7 @@ jobs:
       - id: cache_path
         run: echo cache_path=${{ runner.temp }}/data/ >> $GITHUB_OUTPUT
       - id: version
-        run: echo "version=$(cat ${{ steps.cache_path.outputs.cache_path }}/version.txt)" >> $GITHUB_OUTPUT
+        run: echo "version=$(cat ${{ steps.cache_path.outputs.cache_path }}/webbpsf-data/version.txt)" >> $GITHUB_OUTPUT
       - id: cache_key
         run: echo "cache_key=webbpsf-data-${{ (github.event_name == 'schedule' || github.event_name == 'release') && 'mini' || inputs.minimal && 'mini' || 'full' }}-${{ steps.version.outputs.version }}" >> $GITHUB_OUTPUT
       - uses: actions/cache/save@v4


### PR DESCRIPTION
when running `download_data.yml`, the `data/` directory doesn't exist, so `tar` can't extract into it. Additionally, `version.txt` is now at `data/webbpsf-data/version.txt`