### PR TITLE
Use MASK_NRM to match AMI data

### DIFF
--- a/webbpsf/match_data.py
+++ b/webbpsf/match_data.py
@@ -78,6 +78,10 @@ def setup_sim_to_match_file(filename_or_HDUList, verbose=True, plot=False, choic
         if header['APERNAME'] == 'MIRIM_SLIT':
             inst.image_mask = 'LRS slit'
 
+    elif inst.name == 'NIRISS':
+        if header['PUPIL'] == 'NRM': # else could be CLEARP for KPI observations
+            inst.pupil_mask = 'MASK_NRM'
+
     # TODO add other per-instrument keyword checks
 
     if verbose:


### PR DESCRIPTION
Small addition to automatically set up instrument with NRM for NIRISS AMI exposures. Currently it gets set up with CLEARP, e.g.:
```
Configured simulation instrument for:
    Instrument: NIRISS
    Filter: F430M
    Detector: NIS
    Apername: NIS_AMI1
    Det. Pos.: (46, 41) in subarray
    Image plane mask: None
    Pupil plane mask: CLEARP
```

This change results in: 

```
Configured simulation instrument for:
    Instrument: NIRISS
    Filter: F430M
    Detector: NIS
    Apername: NIS_AMI1
    Det. Pos.: (46, 41) in subarray
    Image plane mask: None
    Pupil plane mask: MASK_NRM
```
