### PR TITLE
Update NIRSpec aperture PAs

### DIFF
--- a/webbpsf/tests/test_nirspec.py
+++ b/webbpsf/tests/test_nirspec.py
@@ -61,11 +61,13 @@ def test_calc_datacube_fast():
 def test_mode_switch():
     """Test switch between IFU and imaging modes"""
     nrs = webbpsf_core.NIRSpec()
+    nrs_default_v3pa = nrs._rotation
     # check mode swith to IFU
     nrs.mode = 'IFU'
     assert 'IFU' in nrs.aperturename
     assert nrs.band == 'PRISM/CLEAR'
     assert nrs.image_mask is None
+    assert nrs._rotation != nrs_default_v3pa
 
     # check switch of which IFU band
     nrs.disperser = 'G395H'
@@ -75,6 +77,7 @@ def test_mode_switch():
     # check mode switch back to imaging
     nrs.mode = 'imaging'
     assert 'IFU' not in nrs.aperturename
+    assert nrs._rotation == nrs_default_v3pa
 
 
 def test_IFU_wavelengths():
@@ -91,3 +94,23 @@ def test_IFU_wavelengths():
     # and test we can specify a reduced wavelength sampling:
     for n in (10, 100):
         assert len(nrs.get_IFU_wavelengths(n)) == n
+
+
+def test_aperture_rotation_updates():
+    """ Test that switching detector or aperture updates the aperture PA
+    (this is a tiny detail)"""
+    nrs = webbpsf_core.NIRSpec()
+    pa_nrs1_full = nrs._rotation
+
+    # changing aperture updates PA
+    nrs.set_position_from_aperture_name('NRS_S200A1_SLIT')
+    assert nrs._rotation != pa_nrs1_full
+
+    # change back to original aperture
+    nrs.set_position_from_aperture_name('NRS1_FULL')
+    assert nrs._rotation == pa_nrs1_full
+
+    # changing detector should update aperturename and also update PA
+    nrs.detector = 'NRS2'
+    assert nrs.aperturename == 'NRS2_FULL'
+    assert nrs._rotation != pa_nrs1_full

--- a/webbpsf/webbpsf_core.py
+++ b/webbpsf/webbpsf_core.py
@@ -3327,6 +3327,9 @@ class NIRSpec(JWInstrument_with_IFU):
                         self.image_mask = None
                 else:
                     self._mode = 'imaging'  # More to implement here later!
+        # Update the rotation angle
+        # This works the same for both regular and IFU modes
+        self._rotation = self._get_aperture_rotation(self.aperturename)
 
     def _tel_coords(self):
         """Convert from science frame coordinates to telescope frame coordinates using
@@ -3355,6 +3358,19 @@ class NIRSpec(JWInstrument_with_IFU):
             return super()._get_pixelscale_from_apername('NRS1_FULL')
         else:
             return super()._get_pixelscale_from_apername(apername)
+
+    def _get_aperture_rotation(self, apername):
+        """Get the rotation angle of a given aperture, using values from SIAF.
+
+        Returns ~ position angle counterclockwise from the V3 axis, in degrees
+        (i.e. SIAF V3IdlYangle)
+
+        For NIRSpec this is simple, since even the SLIT type apertures have
+        V3IdlYAngle values defined.  And we don't have the complexity of
+        COMPOUND type apertures that MIRI has to deal with.
+
+        """
+        return self.siaf[apername].V3IdlYAngle
 
     @property
     def disperser(self):


### PR DESCRIPTION
This addresses issue #868 by updating the NIRSpec aperture PAs from PySIAF, including the very slightly different aperture PAs for NRS1 vs NRS2 and for different apertures such as the IFU or slit apertures. Tiny effect, fraction of a degree, so will have only a small effect on PSFs at most. But it's easy to do so we might as well. (Much simpler than the corresponding code for MIRI which I already wrote in #770).