### PR TITLE
mark display_psf_grid as deprecated

### DIFF
--- a/webbpsf/gridded_library.py
+++ b/webbpsf/gridded_library.py
@@ -1,6 +1,7 @@
 import itertools
 import os
 from collections import OrderedDict
+import astropy.utils.decorators
 
 import astropy.convolution
 import numpy as np
@@ -551,6 +552,7 @@ class CreatePSFLibrary:
         hdu.writeto(file, overwrite=self.overwrite)
 
 
+@astropy.utils.decorators.deprecated('1.3.0', alternative='photutils.psf.GriddedPSFModel.plot_grid')
 def display_psf_grid(grid, zoom_in=True, figsize=(14, 12), scale_range=1e-4, diff_scale_range=1, cmap=None):
     """Display a PSF grid in a pair of plots
 


### PR DESCRIPTION
This addresses #887 by marking `display_psf_grid` as deprecated, using an astropy decorator for marking deprecation. 

I'm not actually sure this is the best way to do this, and welcome suggestions if there's a better way. I see there's also a PEP 702 to add a similar `@deprecated` to the standard library but it's not yet available even in py 3.12, so that doesn't work.   In any case we can informally deprecate (and I'm separately revising the docs and example code in #899 already), so this PR is just attempting to mark the deprecation in code, in some suitable manner. 