### PR TITLE
[CI] allow manual run of `download_data.yml` to specify data URL

### DIFF
--- a/.github/workflows/download_data.yml
+++ b/.github/workflows/download_data.yml
@@ -27,8 +27,13 @@ name: download and cache data
 on:
   workflow_call:
     inputs:
+      url:
+        description: URL to gzip file
+        type: string
+        required: false
+        default: https://stsci.box.com/shared/static/0dt9z6b927iqgtify2a4cvls9hvapi6k.gz
       minimal:
-        description: minimal dataset
+        description: dataset is minimal (as opposed to full)
         type: boolean
         required: false
         default: true
@@ -41,17 +46,25 @@ on:
         value: ${{ jobs.download.outputs.cache_key }}
   workflow_dispatch:
     inputs:
+      url:
+        description: URL to gzip file
+        type: string
+        required: false
+        default: https://stsci.box.com/shared/static/0dt9z6b927iqgtify2a4cvls9hvapi6k.gz
       minimal:
-        description: minimal dataset
+        description: dataset is minimal (as opposed to full)
         type: boolean
         required: false
         default: true
   schedule:
     - cron: "0 0 * * 0"
   release:
+  push:
+    branches:
+      - develop
 
 env:
-  DATA_URL: https://stsci.box.com/shared/static/qxpiaxsjwo15ml6m4pkhtk36c9jgj70k.gz
+  FULL_DATA_URL: https://stsci.box.com/shared/static/qxpiaxsjwo15ml6m4pkhtk36c9jgj70k.gz
   MINIMAL_DATA_URL: https://stsci.box.com/shared/static/0dt9z6b927iqgtify2a4cvls9hvapi6k.gz
 
 jobs:
@@ -59,7 +72,7 @@ jobs:
     name: download and cache WebbPSF data
     runs-on: ubuntu-latest
     steps:
-      - run: wget ${{ (github.event_name == 'schedule' || github.event_name == 'release') && env.MINIMAL_DATA_URL || inputs.minimal && env.MINIMAL_DATA_URL || env.DATA_URL }} -O ${{ runner.temp }}/webbpsf-data.tar.gz
+      - run: wget ${{ (github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call') && inputs.url || env.MINIMAL_DATA_URL }} -O ${{ runner.temp }}/webbpsf-data.tar.gz
       - run: mkdir ${{ runner.temp }}/data/
       - run: tar -xzvf ${{ runner.temp }}/webbpsf-data.tar.gz -C ${{ runner.temp }}/data/
       - id: cache_path


### PR DESCRIPTION
adds the `url` input to the `Run Workflow` box (auto-populated with the minimal data URL by default). This way, if a new data cache is needed, simply run `download_data.yml` (https://github.com/spacetelescope/webbpsf/actions/workflows/download_data.yml) on the default branch (`develop`) and enter the new data URL