### PR TITLE
Implemeted MRI IFU empirical cruciform

### DIFF
--- a/webbpsf/constants.py
+++ b/webbpsf/constants.py
@@ -405,5 +405,5 @@ MIRI_CRUCIFORM_RADIAL_SCALEFACTOR = 0.005   # Brightness factor for the diffuse 
 # Parameters for adjusting models of IFU PSFs relative to regular imaging PSFs
 INSTRUMENT_IFU_BROADENING_PARAMETERS = {
     'NIRSPEC': {'sigma': 0.05},
-    'MIRI': {'sigma': 0.05},
+    'MIRI': {'sigma': 0.05, 'fhwm_cruciform': 15, "offset_cruciform": -3},
 }


### PR DESCRIPTION
This is the the start of a PR for finalising the broadening and cruciform implementation for the MIRI IFU mode. Added an additional option for ```model_type = "cruciform"```

Remaining tasks: 

- [ ] check normalisation convention when modifying PSF models
- [ ] changing the ```oversample``` parameter yields quite significant differences in the PSF models
- [ ] switch empirical broadening (now following Law+2023) to broadening due to sampling by detector and cube pixels


![image](https://github.com/user-attachments/assets/49c8fd09-cda7-4906-918b-6df9dcc8574c)
