### PR TITLE
update MAST query for OPDs to also retrieve OPDs from FP6

### DIFF
--- a/webbpsf/mast_wss.py
+++ b/webbpsf/mast_wss.py
@@ -357,7 +357,7 @@ def infer_pre_or_post_correction(row):
         return 'UNKNOWN'
 
 
-def retrieve_mast_opd_table(aperture_list=['NRCA3_FP1'], verbose=False):
+def retrieve_mast_opd_table(aperture_list=['NRCA3_FP1', 'NRCA1_FP6'], verbose=False):
     """Retrieve table of OPDs from MAST.
 
     Returns : Astropy table listing available OPDs and metadata such as dates and sensing type.

--- a/webbpsf/webbpsf_core.py
+++ b/webbpsf/webbpsf_core.py
@@ -1697,11 +1697,11 @@ class JWInstrument(SpaceTelescopeInstrument):
             axes[0, 0].set_xlabel(f'RMS: {utils.rms(opdhdu[0].data*1e9, ote_pupil_mask):.2f} nm rms')
 
         if backout_si_wfe:
-            if verbose:
-                print('Backing out SI WFE and OTE field dependence at the WF sensing field point')
-
             # Check which field point was used for sensing
             sensing_apername = opdhdu[0].header['APERNAME']
+
+            if verbose:
+                print(f'Backing out SI WFE and OTE field dependence at the WF sensing field point ({sensing_apername})')
 
             # Create a temporary instance of an instrument, for the sensng instrument and field point,
             # in order to model and extract the SI WFE and OTE field dep WFE at the sensing field point.


### PR DESCRIPTION
A little bit more for the field point switch, from testing this evening. 
- Update `retrieve_mast_opd_table` to retrieve from both FP1 + FP6 by default.  This is necessary for it to find the OPDs from the new field point, for use in all the trending tools. 
- Update `load_wss_opd_by_date` debug/verbose message to include which field point was used.  This is just a small cosmetic convenience. 