### PR TITLE
fix download workflow

### DIFF
--- a/.github/workflows/download_data.yml
+++ b/.github/workflows/download_data.yml
@@ -81,7 +81,7 @@ jobs:
         run: echo "version=$(cat ${{ steps.cache_path.outputs.cache_path }}/webbpsf-data/version.txt)" >> $GITHUB_OUTPUT
       - id: cache_key
         run: echo "cache_key=webbpsf-data-${{ (github.event_name == 'schedule' || github.event_name == 'release') && 'mini' || inputs.minimal && 'mini' || 'full' }}-${{ steps.version.outputs.version }}" >> $GITHUB_OUTPUT
-      - uses: actions/cache/save@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9  # v4.0.2
+      - uses: actions/cache/save@1bd1e32a3bdc45362d1e726936510720a7c30a57  # v4.2.0
         with:
           path: ${{ runner.temp }}/data/
           key: ${{ steps.cache_key.outputs.cache_key }}


### PR DESCRIPTION
The download workflow is failing for romancal resulting in failures downloading webbpsf data:
https://github.com/spacetelescope/romancal/actions/runs/13316268671

This is likely due to changes to the `actions/cache` infrastruction:
https://github.com/actions/cache/releases/tag/v4.2.0
with the important bit being:
> We are deprecating some versions of this action. We recommend upgrading to version v4 or v3 as soon as possible before February 1st, 2025. (Upgrade instructions below).
> 
> If you are using pinned SHAs, please use the SHAs of versions v4.2.0 or v3.4.0
>
> If you do not upgrade, all workflow runs using any of the deprecated [actions/cache](https://github.com/actions/cache) will fail.

Since the workflow has an exact pin to v4.0.2 this may explain why the caches suddenly started failing.