### PR TITLE
only using mini in workflow.  name accordingly

### DIFF
--- a/.github/workflows/download_data.yml
+++ b/.github/workflows/download_data.yml
@@ -78,7 +78,7 @@ jobs:
       - id: version
         run: echo "version=$(cat ${{ steps.cache_path.outputs.cache_path }}/webbpsf-data/version.txt)" >> $GITHUB_OUTPUT
       - id: cache_key
-        run: echo "cache_key=webbpsf-data-${{ (github.event_name == 'schedule' || github.event_name == 'release') && 'mini' || inputs.minimal && 'mini' || 'full' }}-${{ steps.version.outputs.version }}" >> $GITHUB_OUTPUT
+        run: echo "cache_key=webbpsf-data-mini-${{ steps.version.outputs.version }}" >> $GITHUB_OUTPUT
       - uses: actions/cache@v4
         with:
           path: ${{ runner.temp }}/data/


### PR DESCRIPTION
stop populating "full" cache filename as we are only using "mini"