### PR TITLE
add back-compatibility alias for get_webbpsf_data_path

### DIFF
--- a/webbpsf/__init__.py
+++ b/webbpsf/__init__.py
@@ -36,3 +36,7 @@ if not _warned:
 
     sys.modules["webbpsf"] = stpsf
     os.environ["STPSF_PATH"] = os.environ.get("WEBBPSF_PATH", "")
+
+    # Add a back-compatibility alias for a function whose name changed during the migration
+    # This prevents failure of legacy code calls to webbpsf.utils.get_webbpsf_data_path()
+    stpsf.utils.get_webbpsf_data_path = stpsf.utils.get_stpsf_data_path


### PR DESCRIPTION
Whoops, looks like one function got missed or overlooked accidentally in the repo migration: The function `webbpsf.utils.get_webbpsf_data_path()` doesn't simply work via the `sys.modules` redirect, because the function name changed to `get_stpsf_data_path()`. The lack of this function breaks at least some existing legacy code, in the [webbpsf_ext](https://github.com/JarronL/webbpsf_ext) repo. 

This PR addresses that by manually adding an alias for that to the `stpsf` namespace, such that calls to `webbpsf.utils.get_webbpsf_data_path()` will correctly invoke `stpsf.utils.get_stpsf_data_path()`. 
